### PR TITLE
Fix broken requirement name for attrs

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,3 +4,4 @@ include CODE_OF_CONDUCT.md
 include CONTRIBUTING.md
 include AUTHORS.md
 include versioneer.py
+include requirements.txt

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@ PROJECT=boule
 TESTDIR=tmp-test-dir-with-unique-name
 PYTEST_ARGS=--cov-config=../.coveragerc --cov-report=term-missing --cov=$(PROJECT) --doctest-modules -v --pyargs
 LINT_FILES=setup.py $(PROJECT)
-BLACK_FILES=setup.py $(PROJECT) examples tutorials
-FLAKE8_FILES=setup.py $(PROJECT) examples
+BLACK_FILES=setup.py $(PROJECT) tutorials
+FLAKE8_FILES=setup.py $(PROJECT)
 
 help:
 	@echo "Commands:"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 numpy
-attr
+attrs


### PR DESCRIPTION
Misspelled as attr. Include requirements.txt in the MANIFEST.



**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
