### PR TITLE
Spherical to geodetic and inverse transformations

### DIFF
--- a/boule/ellipsoid.py
+++ b/boule/ellipsoid.py
@@ -145,3 +145,105 @@ class Ellipsoid:
             self.geocentric_grav_const * (1 + self.emm * aux) / self.semimajor_axis ** 2
         )
         return result
+
+    def geodetic_to_spherical(self, longitude, latitude, height):
+        """
+        Convert from geodetic to geocentric spherical coordinates.
+
+        The geodetic datum is defined by this ellipsoid. The coordinates are
+        converted following [Vermeille2002]_.
+
+        Parameters
+        ----------
+        longitude : array
+            Longitude coordinates on geodetic coordinate system in degrees.
+        latitude : array
+            Latitude coordinates on geodetic coordinate system in degrees.
+        height : array
+            Ellipsoidal heights in meters.
+
+        Returns
+        -------
+        longitude : array
+            Longitude coordinates on geocentric spherical coordinate system in
+            degrees.
+            The longitude coordinates are not modified during this conversion.
+        spherical_latitude : array
+            Converted latitude coordinates on geocentric spherical coordinate
+            system in degrees.
+        radius : array
+            Converted spherical radius coordinates in meters.
+
+        """
+        latitude_rad = np.radians(latitude)
+        prime_vertical_radius = self.semimajor_axis / np.sqrt(
+            1 - self.first_eccentricity ** 2 * np.sin(latitude_rad) ** 2
+        )
+        # Instead of computing X and Y, we only compute the projection on the
+        # XY plane: xy_projection = sqrt( X**2 + Y**2 )
+        xy_projection = (height + prime_vertical_radius) * np.cos(latitude_rad)
+        z_cartesian = (
+            height + (1 - self.first_eccentricity ** 2) * prime_vertical_radius
+        ) * np.sin(latitude_rad)
+        radius = np.sqrt(xy_projection ** 2 + z_cartesian ** 2)
+        spherical_latitude = np.degrees(np.arcsin(z_cartesian / radius))
+        return longitude, spherical_latitude, radius
+
+    def spherical_to_geodetic(self, longitude, spherical_latitude, radius):
+        """
+        Convert from geocentric spherical to geodetic coordinates.
+
+        The geodetic datum is defined by this ellipsoid. The coordinates are
+        converted following [Vermeille2002]_.
+
+        Parameters
+        ----------
+        longitude : array
+            Longitude coordinates on geocentric spherical coordinate system in
+            degrees.
+        spherical_latitude : array
+            Latitude coordinates on geocentric spherical coordinate system in
+            degrees.
+        radius : array
+            Spherical radius coordinates in meters.
+
+        Returns
+        -------
+        longitude : array
+            Longitude coordinates on geodetic coordinate system in degrees.
+            The longitude coordinates are not modified during this conversion.
+        latitude : array
+            Converted latitude coordinates on geodetic coordinate system in
+            degrees.
+        height : array
+            Converted ellipsoidal height coordinates in meters.
+
+        """
+        spherical_latitude_rad = np.radians(spherical_latitude)
+        big_z = radius * np.sin(spherical_latitude_rad)
+        p_0 = (
+            radius ** 2 * np.cos(spherical_latitude_rad) ** 2 / self.semimajor_axis ** 2
+        )
+        q_0 = (1 - self.first_eccentricity ** 2) / self.semimajor_axis ** 2 * big_z ** 2
+        r_0 = (p_0 + q_0 - self.first_eccentricity ** 4) / 6
+        s_0 = self.first_eccentricity ** 4 * p_0 * q_0 / 4 / r_0 ** 3
+        t_0 = np.cbrt(1 + s_0 + np.sqrt(2 * s_0 + s_0 ** 2))
+        u_0 = r_0 * (1 + t_0 + 1 / t_0)
+        v_0 = np.sqrt(u_0 ** 2 + q_0 * self.first_eccentricity ** 4)
+        w_0 = self.first_eccentricity ** 2 * (u_0 + v_0 - q_0) / 2 / v_0
+        k = np.sqrt(u_0 + v_0 + w_0 ** 2) - w_0
+        big_d = (
+            k
+            * radius
+            * np.cos(spherical_latitude_rad)
+            / (k + self.first_eccentricity ** 2)
+        )
+        latitude = np.degrees(
+            2 * np.arctan(big_z / (big_d + np.sqrt(big_d ** 2 + big_z ** 2)))
+        )
+        height = (
+            (k + self.first_eccentricity ** 2 - 1)
+            / k
+            * np.sqrt(big_d ** 2 + big_z ** 2)
+        )
+        return longitude, latitude, height

--- a/boule/tests/test_ellipsoid.py
+++ b/boule/tests/test_ellipsoid.py
@@ -1,0 +1,128 @@
+"""
+Test the base Ellipsoid class.
+"""
+import pytest
+import numpy as np
+import numpy.testing as npt
+
+from .. import Ellipsoid, WGS84
+
+
+@pytest.fixture
+def sphere():
+    "A spherical ellipsoid"
+    ellipsoid = Ellipsoid(
+        name="unit_sphere",
+        semimajor_axis=1.0,
+        flattening=0,
+        geocentric_grav_const=0,
+        angular_velocity=0,
+    )
+    return ellipsoid
+
+
+def test_geodetic_to_spherical_with_spherical_ellipsoid(sphere):
+    "Test geodetic to geocentric conversion if ellipsoid is a sphere."
+    rtol = 1e-10
+    size = 5
+    longitude = np.linspace(0, 180, size)
+    latitude = np.linspace(-90, 90, size)
+    height = np.linspace(-0.2, 0.2, size)
+    sph_longitude, sph_latitude, radius = sphere.geodetic_to_spherical(
+        longitude, latitude, height
+    )
+    npt.assert_allclose(sph_longitude, longitude, rtol=rtol)
+    npt.assert_allclose(sph_latitude, latitude, rtol=rtol)
+    npt.assert_allclose(radius, sphere.mean_radius + height, rtol=rtol)
+
+
+def test_spherical_to_geodetic_with_spherical_ellipsoid(sphere):
+    "Test spherical to geodetic conversion if ellipsoid is a sphere."
+    rtol = 1e-10
+    size = 5
+    spherical_longitude = np.linspace(0, 180, size)
+    spherical_latitude = np.linspace(-90, 90, size)
+    radius = np.linspace(0.8, 1.2, size)
+    longitude, latitude, height = sphere.spherical_to_geodetic(
+        spherical_longitude, spherical_latitude, radius
+    )
+    npt.assert_allclose(spherical_longitude, longitude, rtol=rtol)
+    npt.assert_allclose(spherical_latitude, latitude, rtol=rtol)
+    npt.assert_allclose(radius, sphere.mean_radius + height, rtol=rtol)
+
+
+def test_geodetic_to_spherical_on_equator():
+    "Test geodetic to geocentric coordinates conversion on equator."
+    rtol = 1e-10
+    size = 5
+    longitude = np.linspace(0, 180, size)
+    height = np.linspace(-1e4, 1e4, size)
+    latitude = np.zeros_like(size)
+    ellipsoid = WGS84()
+    sph_longitude, sph_latitude, radius = ellipsoid.geodetic_to_spherical(
+        longitude, latitude, height
+    )
+    npt.assert_allclose(sph_longitude, longitude, rtol=rtol)
+    npt.assert_allclose(sph_latitude, latitude, rtol=rtol)
+    npt.assert_allclose(radius, height + ellipsoid.semimajor_axis, rtol=rtol)
+
+
+def test_geodetic_to_spherical_on_poles():
+    "Test geodetic to geocentric coordinates conversion on poles."
+    rtol = 1e-10
+    size = 5
+    longitude = np.hstack([np.linspace(0, 180, size)] * 2)
+    height = np.hstack([np.linspace(-1e4, 1e4, size)] * 2)
+    latitude = np.array([90.0] * size + [-90.0] * size)
+    ellipsoid = WGS84()
+    sph_longitude, sph_latitude, radius = ellipsoid.geodetic_to_spherical(
+        longitude, latitude, height
+    )
+    npt.assert_allclose(sph_longitude, longitude, rtol=rtol)
+    npt.assert_allclose(sph_latitude, latitude, rtol=rtol)
+    npt.assert_allclose(radius, height + ellipsoid.semiminor_axis, rtol=rtol)
+
+
+def test_spherical_to_geodetic_on_equator():
+    "Test spherical to geodetic coordinates conversion on equator."
+    rtol = 1e-10
+    size = 5
+    spherical_latitude = np.zeros(size)
+    ellipsoid = WGS84()
+    spherical_longitude = np.linspace(0, 180, size)
+    radius = np.linspace(-1e4, 1e4, size) + ellipsoid.semimajor_axis
+    longitude, latitude, height = ellipsoid.spherical_to_geodetic(
+        spherical_longitude, spherical_latitude, radius
+    )
+    npt.assert_allclose(spherical_longitude, longitude, rtol=rtol)
+    npt.assert_allclose(spherical_latitude, latitude, rtol=rtol)
+    npt.assert_allclose(radius, height + ellipsoid.semimajor_axis, rtol=rtol)
+
+
+def test_spherical_to_geodetic_on_poles():
+    "Test spherical to geodetic coordinates conversion on poles."
+    rtol = 1e-10
+    size = 5
+    spherical_longitude = np.hstack([np.linspace(0, 180, size)] * 2)
+    spherical_latitude = np.array([90.0] * size + [-90.0] * size)
+    ellipsoid = WGS84()
+    radius = np.hstack([np.linspace(-1e4, 1e4, size) + ellipsoid.semiminor_axis] * 2)
+    longitude, latitude, height = ellipsoid.spherical_to_geodetic(
+        spherical_longitude, spherical_latitude, radius
+    )
+    npt.assert_allclose(spherical_longitude, longitude, rtol=rtol)
+    npt.assert_allclose(spherical_latitude, latitude, rtol=rtol)
+    npt.assert_allclose(radius, height + ellipsoid.semiminor_axis, rtol=rtol)
+
+
+def test_spherical_to_geodetic_identity():
+    "Test if applying both conversions in series is the identity operator"
+    rtol = 1e-10
+    longitude = np.linspace(0, 350, 36)
+    latitude = np.linspace(-90, 90, 19)
+    height = np.linspace(-1e4, 1e4, 8)
+    coordinates = np.meshgrid(longitude, latitude, height)
+    ellipsoid = WGS84()
+    spherical_coordinates = ellipsoid.geodetic_to_spherical(*coordinates)
+    reconverted_coordinates = ellipsoid.spherical_to_geodetic(*spherical_coordinates)
+    npt.assert_allclose(coordinates, reconverted_coordinates, rtol=rtol)

--- a/boule/tests/test_ellipsoid.py
+++ b/boule/tests/test_ellipsoid.py
@@ -1,3 +1,4 @@
+# pylint: disable=redefined-outer-name
 """
 Test the base Ellipsoid class.
 """

--- a/doc/_templates/autosummary/class.rst
+++ b/doc/_templates/autosummary/class.rst
@@ -13,7 +13,7 @@
 
  {% if methods|length > 1 %}
 
-.. rubric:: Methods Summary
+.. rubric:: Methods
 
 .. autosummary::
     {% for item in methods %}

--- a/doc/references.rst
+++ b/doc/references.rst
@@ -2,3 +2,4 @@ References
 ==========
 
 .. [Hofmann-WellenhofMoritz2006] Hofmann-Wellenhof, B., & Moritz, H. (2006). Physical Geodesy (2nd, corr. ed. 2006 edition ed.). Wien ; New York: Springer.
+.. [Vermeille2002] Vermeille, H., 2002. Direct transformation from geocentric coordinates to geodetic coordinates. Journal of Geodesy. 76. 451-454. doi:`10.1007/s00190-002-0273-6 <https://doi.org/10.1007/s00190-002-0273-6>`__


### PR DESCRIPTION
Add methods to Ellipsoid to transform coordinates from geodetic to
spherical and back again. Copied from Harmonica. Added as methods to
avoid passing "ellipsoid" all the time or having to use a global
ellipsoid.


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
