### PR TITLE
Fix typo on Boule description in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,7 +54,7 @@ The main use cases are:
   coordinate conversions.
 * Input ellipsoid parameters for spherical harmonic analysis.
 
-Boule is French for "ball" and also a `traditional shape of break resembling a
+Boule is French for "ball" and also a `traditional shape of bread resembling a
 squashed ball <https://en.wikipedia.org/wiki/Boule_(bread)>`__.
 
 


### PR DESCRIPTION
Fix typo on Boulde description in README.md file.
It said `break` where it should be saying `bread`.


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.