### PR TITLE
Add CI testing and setup.py flags for Python 3.8

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -80,6 +80,9 @@ jobs:
 
   strategy:
     matrix:
+      Python38:
+        python.version: '3.8'
+        PYTHON: '3.8'
       Python37:
         python.version: '3.7'
         PYTHON: '3.7'
@@ -163,6 +166,9 @@ jobs:
 
   strategy:
     matrix:
+      Python38:
+        python.version: '3.8'
+        PYTHON: '3.8'
       Python37:
         python.version: '3.7'
         PYTHON: '3.7'

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,10 @@ env:
 # Specify the build configurations. Be sure to only deploy from a single build.
 matrix:
     include:
+        - name: "Linux - Python 3.8"
+          os: linux
+          env:
+              - PYTHON=3.8
         # Main build to deploy to PyPI and Github pages
         - name: "Linux - Python 3.7 (deploy)"
           os: linux

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ CLASSIFIERS = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
     "License :: OSI Approved :: {}".format(LICENSE),
 ]
 PLATFORMS = "Any"


### PR DESCRIPTION
Add builds using Python 3.8 to the CIs so we know tests pass. On
setup.py, only need to add metadata flags saying that we're compatible
with 3.8.



**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
