### PR TITLE
Make ellipsoids instances not subclasses

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Build, package, test, and clean
 PROJECT=boule
 TESTDIR=tmp-test-dir-with-unique-name
-PYTEST_ARGS=--cov-config=../.coveragerc --cov-report=term-missing --cov=$(PROJECT) --doctest-modules -v --pyargs
+PYTEST_ARGS=--cov-config=../.coveragerc --cov-report=term-missing --cov=$(PROJECT) --doctest-modules --doctest-glob='*.rst' -v --pyargs
 LINT_FILES=setup.py $(PROJECT)
 BLACK_FILES=setup.py doc/conf.py $(PROJECT) tutorials
 FLAKE8_FILES=setup.py $(PROJECT)
@@ -23,7 +23,7 @@ install:
 test:
 	# Run a tmp folder to make sure the tests are run on the installed version
 	mkdir -p $(TESTDIR)
-	cd $(TESTDIR); MPLBACKEND='agg' pytest $(PYTEST_ARGS) $(PROJECT)
+	cd $(TESTDIR); MPLBACKEND='agg' pytest $(PYTEST_ARGS) $(PROJECT) ../doc/*.rst
 	cp $(TESTDIR)/.coverage* .
 	rm -rvf $(TESTDIR)
 

--- a/boule/earth.py
+++ b/boule/earth.py
@@ -1,57 +1,18 @@
 """
-Earth ellipsoids
+Earth ellipsoids.
 """
 from .ellipsoid import Ellipsoid
 
 
-class WGS84(Ellipsoid):
-    """
-    World Geodetic System 1984.
-
-    The WGS84 ellipsoid as defined by the values given in
-    [Hofmann-WellenhofMoritz2006]_.
-
-    Note that the ellipsoid gravity at the pole differs from
-    [Hofmann-WellenhofMoritz2006]_ on the last digit. This is sufficiently
-    small as to not be a cause for concern.
-
-    Examples
-    --------
-
-    >>> wgs84 = WGS84()
-    >>> print(wgs84) # doctest: +ELLIPSIS
-    WGS84(name='WGS84', ...)
-    >>> print("{:.4f}".format(wgs84.semiminor_axis))
-    6356752.3142
-    >>> print("{:.7f}".format(wgs84.flattening))
-    0.0033528
-    >>> print("{:.13e}".format(wgs84.linear_eccentricity))
-    5.2185400842339e+05
-    >>> print("{:.13e}".format(wgs84.first_eccentricity))
-    8.1819190842621e-02
-    >>> print("{:.13e}".format(wgs84.second_eccentricity))
-    8.2094437949696e-02
-    >>> print("{:.4f}".format(wgs84.mean_radius))
-    6371008.7714
-    >>> print("{:.14f}".format(wgs84.emm))
-    0.00344978650684
-    >>> print("{:.10f}".format(wgs84.gravity_equator))
-    9.7803253359
-    >>> print("{:.10f}".format(wgs84.gravity_pole))
-    9.8321849379
-
-    """
-
-    def __init__(self):
-        super().__init__(
-            name="WGS84",
-            long_name="World Geodetic System 1984",
-            semimajor_axis=6378137,
-            flattening=1 / 298.257223563,
-            geocentric_grav_const=3986004.418e8,
-            angular_velocity=7292115e-11,
-            reference=(
-                "Hofmann-Wellenhof, B., & Moritz, H. (2006). Physical Geodesy "
-                "(2nd, corr. ed. 2006 edition ed.). Wien ; New York: Springer."
-            ),
-        )
+WGS84 = Ellipsoid(
+    name="WGS84",
+    long_name="World Geodetic System 1984",
+    semimajor_axis=6378137,
+    flattening=1 / 298.257223563,
+    geocentric_grav_const=3986004.418e8,
+    angular_velocity=7292115e-11,
+    reference=(
+        "Hofmann-Wellenhof, B., & Moritz, H. (2006). Physical Geodesy "
+        "(2nd, corr. ed. 2006 edition ed.). Wien ; New York: Springer."
+    ),
+)

--- a/boule/tests/test_ellipsoid.py
+++ b/boule/tests/test_ellipsoid.py
@@ -59,7 +59,7 @@ def test_geodetic_to_spherical_on_equator():
     longitude = np.linspace(0, 180, size)
     height = np.linspace(-1e4, 1e4, size)
     latitude = np.zeros_like(size)
-    ellipsoid = WGS84()
+    ellipsoid = WGS84
     sph_longitude, sph_latitude, radius = ellipsoid.geodetic_to_spherical(
         longitude, latitude, height
     )
@@ -75,7 +75,7 @@ def test_geodetic_to_spherical_on_poles():
     longitude = np.hstack([np.linspace(0, 180, size)] * 2)
     height = np.hstack([np.linspace(-1e4, 1e4, size)] * 2)
     latitude = np.array([90.0] * size + [-90.0] * size)
-    ellipsoid = WGS84()
+    ellipsoid = WGS84
     sph_longitude, sph_latitude, radius = ellipsoid.geodetic_to_spherical(
         longitude, latitude, height
     )
@@ -89,7 +89,7 @@ def test_spherical_to_geodetic_on_equator():
     rtol = 1e-10
     size = 5
     spherical_latitude = np.zeros(size)
-    ellipsoid = WGS84()
+    ellipsoid = WGS84
     spherical_longitude = np.linspace(0, 180, size)
     radius = np.linspace(-1e4, 1e4, size) + ellipsoid.semimajor_axis
     longitude, latitude, height = ellipsoid.spherical_to_geodetic(
@@ -106,7 +106,7 @@ def test_spherical_to_geodetic_on_poles():
     size = 5
     spherical_longitude = np.hstack([np.linspace(0, 180, size)] * 2)
     spherical_latitude = np.array([90.0] * size + [-90.0] * size)
-    ellipsoid = WGS84()
+    ellipsoid = WGS84
     radius = np.hstack([np.linspace(-1e4, 1e4, size) + ellipsoid.semiminor_axis] * 2)
     longitude, latitude, height = ellipsoid.spherical_to_geodetic(
         spherical_longitude, spherical_latitude, radius
@@ -123,7 +123,7 @@ def test_spherical_to_geodetic_identity():
     latitude = np.linspace(-90, 90, 19)
     height = np.linspace(-1e4, 1e4, 8)
     coordinates = np.meshgrid(longitude, latitude, height)
-    ellipsoid = WGS84()
+    ellipsoid = WGS84
     spherical_coordinates = ellipsoid.geodetic_to_spherical(*coordinates)
     reconverted_coordinates = ellipsoid.spherical_to_geodetic(*spherical_coordinates)
     npt.assert_allclose(coordinates, reconverted_coordinates, rtol=rtol)

--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -7,21 +7,17 @@ API Reference
 
 .. currentmodule:: boule
 
-Ellipsoids
-----------
-
-.. autosummary::
-   :toctree: generated/
-
-    WGS84
-
-All ellipsoids inherit from the following class:
+Reference Ellipsoid
+-------------------
 
 .. autosummary::
    :toctree: generated/
 
     Ellipsoid
 
+All ellipsoids are instances of the :class:`~boule.Ellipsoid` class. See the
+class reference documentation for a list its derived physical properties
+(attributes) and computations/transformations that it can perform (methods).
 
 Utilities
 ---------

--- a/doc/ellipsoids.rst
+++ b/doc/ellipsoids.rst
@@ -1,0 +1,64 @@
+.. _ellipsoids:
+
+Available Ellipsoids
+====================
+
+These are the available ellipsoids and their corresponding defining parameters.
+
+All ellipsoids are instances of the :class:`~boule.Ellipsoid` class. See the
+class documentation for a list its derived physical properties (attributes) and
+computations/transformations that it can perform (methods).
+
+Earth
+-----
+
+World Geodetic System 1984
+++++++++++++++++++++++++++
+
+The WGS84 ellipsoid as defined by the values given in
+[Hofmann-WellenhofMoritz2006]_:
+
+.. doctest::
+
+    >>> from boule import WGS84
+    >>> print(WGS84)
+    Ellipsoid(name='WGS84', ...)
+    >>> # Inverse flattening
+    >>> print("{:.9f}".format(1 / WGS84.flattening))
+    298.257223563
+    >>> # Semimajor axis
+    >>> print("{:.0f}".format(WGS84.semimajor_axis))
+    6378137
+    >>> # Geocentric gravitational constant (GM)
+    >>> print("{:.9e}".format(WGS84.geocentric_grav_const))
+    3.986004418e+14
+    >>> # Angular velocity
+    >>> print("{:.6e}".format(WGS84.angular_velocity))
+    7.292115e-05
+
+The following are the derived attributes:
+
+.. doctest::
+
+    >>> print("{:.7f}".format(WGS84.flattening))
+    0.0033528
+    >>> print("{:.4f}".format(WGS84.semiminor_axis))
+    6356752.3142
+    >>> print("{:.13e}".format(WGS84.linear_eccentricity))
+    5.2185400842339e+05
+    >>> print("{:.13e}".format(WGS84.first_eccentricity))
+    8.1819190842621e-02
+    >>> print("{:.13e}".format(WGS84.second_eccentricity))
+    8.2094437949696e-02
+    >>> print("{:.4f}".format(WGS84.mean_radius))
+    6371008.7714
+    >>> print("{:.14f}".format(WGS84.emm))
+    0.00344978650684
+    >>> print("{:.10f}".format(WGS84.gravity_equator))
+    9.7803253359
+    >>> print("{:.10f}".format(WGS84.gravity_pole))
+    9.8321849379
+
+Note that the ellipsoid gravity at the pole differs from
+[Hofmann-WellenhofMoritz2006]_ on the last digit.
+This is sufficiently small as to not be a cause for concern.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -22,6 +22,7 @@ Boule
     :hidden:
     :caption: User Guide
 
+    ellipsoids.rst
 
 .. toctree::
     :maxdepth: 2


### PR DESCRIPTION
It's awkward to have to use `WGS84()` when all ellipsoids don't really
take any arguments. Make them instances of the `Ellipsoid` class instead
of subclasses to get rid of `()`. Move the list of ellipsoids to a
separate documentation page and move doctests to that page. Add required
pytest configuration to the Makefile so we can run the doctests in the
rst sources.



**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
