### PR TITLE
Disable codecov PR comments correctly

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -11,4 +11,4 @@ coverage:
         if_not_found: success
         if_ci_failed: failure
 
-comment: off
+comment: false


### PR DESCRIPTION
Was using `comment: off` in the configuration when it should be
`comment: false`.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
