### PR TITLE
Avoid division by cos latitude in normal gravity

### DIFF
--- a/boule/ellipsoid.py
+++ b/boule/ellipsoid.py
@@ -296,7 +296,7 @@ class Ellipsoid:
         "Calculate intermediate terms needed for the calculations."
         # Offload computation of these intermediate variables here to clean up
         # the main function body
-        beta = np.arctan2(self.semiminor_axis * sinlat / coslat, self.semimajor_axis)
+        beta = np.arctan2(self.semiminor_axis * sinlat, self.semimajor_axis * coslat)
         zl2 = (self.semiminor_axis * np.sin(beta) + height * sinlat) ** 2
         rl2 = (self.semimajor_axis * np.cos(beta) + height * coslat) ** 2
         big_d = (rl2 - zl2) / self.linear_eccentricity ** 2


### PR DESCRIPTION
An arctangent term had a division by the cosine of latitude that would
be zero in the poles (causing a zero division warning). The values are
correct by putting the cosine in the second argument of arctan2 makes it
go away.



**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
