### PR TITLE
Update install instructions and mark 0.1.1 release

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -141,5 +141,6 @@ Documentation for other versions
 * `Development <http://www.fatiando.org/boule/dev>`__ (reflects the *master* branch on
   Github)
 * `Latest release <http://www.fatiando.org/boule/latest>`__
+* `v0.1.1 <http://www.fatiando.org/boule/v0.1.1>`__
 * `v0.1.0 <http://www.fatiando.org/boule/v0.1.0>`__
 * `v0.0.1 <http://www.fatiando.org/boule/v0.0.1>`__

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -3,6 +3,16 @@
 Changelog
 =========
 
+Version 0.1.1
+-------------
+
+*Released on: 2020/01/10*
+
+This release contains only a documentation fix: include install instructions
+for conda and pip. No functionality has been changed (hence, no DOI was
+issued).
+
+
 Version 0.1.0
 -------------
 

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -22,6 +22,28 @@ Dependencies
 * `numpy <http://www.numpy.org/>`__
 * `attrs <https://www.attrs.org/>`__
 
+When installing Boule via conda or pip, missing dependencies will be installed
+automatically. You only need to install them manually if using the latest
+development version from GitHub.
+
+
+Installing with conda
+---------------------
+
+You can install Boule using the `conda package manager <https://conda.io/>`__
+that comes with the Anaconda distribution::
+
+    conda install boule --channel conda-forge
+
+
+Installing with pip
+-------------------
+
+Alternatively, you can also use the `pip package manager
+<https://pypi.org/project/pip/>`__::
+
+    pip install boule
+
 
 Installing the latest development version
 -----------------------------------------


### PR DESCRIPTION
Was missing instructions for conda and pip. Mark a new bug fix release
to update the latest documentation pages only.



**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
