### PR TITLE
Add method for computing prime vertical radius

### DIFF
--- a/boule/ellipsoid.py
+++ b/boule/ellipsoid.py
@@ -146,12 +146,11 @@ class Ellipsoid:
         )
         return result
 
-    def _prime_vertical_radius(self, latitude_radians):
-        """
+    def _prime_vertical_radius(self, sinlat):
+        r"""
         Calculate the prime vertical radius for a given latitude
 
         The prime vertical radius is compute following:
-
 
         .. math::
 
@@ -161,16 +160,16 @@ class Ellipsoid:
 
         Parameters
         ----------
-        latitude_radians : float or array-like
-            Latitude values given in radians.
+        sinlat : float or array-like
+            Sine of the latitude angle.
 
         Returns
         -------
         prime_vertical_radius : float or array-like
-            Prime vertical radius given in the same units as the semimajor axis.
+            Prime vertical radius given in the same units as the semimajor axis
         """
         return self.semimajor_axis / np.sqrt(
-            1 - self.first_eccentricity ** 2 * np.sin(latitude_radians) ** 2
+            1 - self.first_eccentricity ** 2 * sinlat ** 2
         )
 
     def geodetic_to_spherical(self, longitude, latitude, height):
@@ -203,13 +202,14 @@ class Ellipsoid:
 
         """
         latitude_rad = np.radians(latitude)
-        prime_vertical_radius = self._prime_vertical_radius(latitude_rad)
+        coslat, sinlat = np.cos(latitude_rad), np.sin(latitude_rad)
+        prime_vertical_radius = self._prime_vertical_radius(sinlat)
         # Instead of computing X and Y, we only compute the projection on the
         # XY plane: xy_projection = sqrt( X**2 + Y**2 )
-        xy_projection = (height + prime_vertical_radius) * np.cos(latitude_rad)
+        xy_projection = (height + prime_vertical_radius) * coslat
         z_cartesian = (
             height + (1 - self.first_eccentricity ** 2) * prime_vertical_radius
-        ) * np.sin(latitude_rad)
+        ) * sinlat
         radius = np.sqrt(xy_projection ** 2 + z_cartesian ** 2)
         spherical_latitude = np.degrees(np.arcsin(z_cartesian / radius))
         return longitude, spherical_latitude, radius
@@ -289,7 +289,7 @@ class Ellipsoid:
             The (geodetic) latitude where the normal gravity will be computed
             (in degrees).
         height : float or array
-            The ellipsoidal (geometric) height of computation point (in meters).
+            The ellipsoidal (geometric) height of computation point (in meters)
 
         Returns
         -------

--- a/boule/ellipsoid.py
+++ b/boule/ellipsoid.py
@@ -146,6 +146,33 @@ class Ellipsoid:
         )
         return result
 
+    def _prime_vertical_radius(self, latitude_radians):
+        """
+        Calculate the prime vertical radius for a given latitude
+
+        The prime vertical radius is compute following:
+
+
+        .. math::
+
+            N(\phi) = \frac{a}{\sqrt{1 - e^2 \sin^2(\phi)}}
+
+        Where $a$ is the semimajor axis and $e$ the first eccentricity.
+
+        Parameters
+        ----------
+        latitude_radians : float or array-like
+            Latitude values given in radians.
+
+        Returns
+        -------
+        prime_vertical_radius : float or array-like
+            Prime vertical radius given in the same units as the semimajor axis.
+        """
+        return self.semimajor_axis / np.sqrt(
+            1 - self.first_eccentricity ** 2 * np.sin(latitude_radians) ** 2
+        )
+
     def geodetic_to_spherical(self, longitude, latitude, height):
         """
         Convert from geodetic to geocentric spherical coordinates.
@@ -176,9 +203,7 @@ class Ellipsoid:
 
         """
         latitude_rad = np.radians(latitude)
-        prime_vertical_radius = self.semimajor_axis / np.sqrt(
-            1 - self.first_eccentricity ** 2 * np.sin(latitude_rad) ** 2
-        )
+        prime_vertical_radius = self._prime_vertical_radius(latitude_rad)
         # Instead of computing X and Y, we only compute the projection on the
         # XY plane: xy_projection = sqrt( X**2 + Y**2 )
         xy_projection = (height + prime_vertical_radius) * np.cos(latitude_rad)

--- a/boule/ellipsoid.py
+++ b/boule/ellipsoid.py
@@ -158,6 +158,8 @@ class Ellipsoid:
 
         Where :math:`a` is the semimajor axis and :math:`e` is the first eccentricity.
 
+        This function receives the sine of the latitude as input to avoid repeated 
+        computations of trigonometric functions.
         Parameters
         ----------
         sinlat : float or array-like

--- a/boule/ellipsoid.py
+++ b/boule/ellipsoid.py
@@ -150,7 +150,7 @@ class Ellipsoid:
         r"""
         Calculate the prime vertical radius for a given geodetic latitude
 
-        The prime vertical radius is compute following:
+        The prime vertical radius is defined as:
 
         .. math::
 

--- a/boule/ellipsoid.py
+++ b/boule/ellipsoid.py
@@ -148,7 +148,7 @@ class Ellipsoid:
 
     def _prime_vertical_radius(self, sinlat):
         r"""
-        Calculate the prime vertical radius for a given latitude
+        Calculate the prime vertical radius for a given geodetic latitude
 
         The prime vertical radius is compute following:
 

--- a/boule/ellipsoid.py
+++ b/boule/ellipsoid.py
@@ -205,7 +205,7 @@ class Ellipsoid:
         """
         latitude_rad = np.radians(latitude)
         coslat, sinlat = np.cos(latitude_rad), np.sin(latitude_rad)
-        prime_vertical_radius = self._prime_vertical_radius(sinlat)
+        prime_vertical_radius = self.prime_vertical_radius(sinlat)
         # Instead of computing X and Y, we only compute the projection on the
         # XY plane: xy_projection = sqrt( X**2 + Y**2 )
         xy_projection = (height + prime_vertical_radius) * coslat

--- a/boule/ellipsoid.py
+++ b/boule/ellipsoid.py
@@ -156,7 +156,7 @@ class Ellipsoid:
 
             N(\phi) = \frac{a}{\sqrt{1 - e^2 \sin^2(\phi)}}
 
-        Where $a$ is the semimajor axis and $e$ the first eccentricity.
+        Where :math:`a` is the semimajor axis and :math:`e` is the first eccentricity.
 
         Parameters
         ----------

--- a/boule/ellipsoid.py
+++ b/boule/ellipsoid.py
@@ -146,7 +146,7 @@ class Ellipsoid:
         )
         return result
 
-    def _prime_vertical_radius(self, sinlat):
+    def prime_vertical_radius(self, sinlat):
         r"""
         Calculate the prime vertical radius for a given geodetic latitude
 

--- a/boule/ellipsoid.py
+++ b/boule/ellipsoid.py
@@ -158,8 +158,9 @@ class Ellipsoid:
 
         Where :math:`a` is the semimajor axis and :math:`e` is the first eccentricity.
 
-        This function receives the sine of the latitude as input to avoid repeated 
+        This function receives the sine of the latitude as input to avoid repeated
         computations of trigonometric functions.
+
         Parameters
         ----------
         sinlat : float or array-like
@@ -291,7 +292,7 @@ class Ellipsoid:
             The (geodetic) latitude where the normal gravity will be computed
             (in degrees).
         height : float or array
-            The ellipsoidal (geometric) height of computation point (in meters)
+            The ellipsoidal (geometric) height of computation point (in meters).
 
         Returns
         -------

--- a/boule/tests/test_ellipsoid.py
+++ b/boule/tests/test_ellipsoid.py
@@ -175,11 +175,18 @@ def test_normal_gravity_non_zero_height(ellipsoid):
 
 @pytest.mark.parametrize("ellipsoid", ELLIPSOIDS, ids=ELLIPSOID_NAMES)
 def test_prime_vertical_radius(ellipsoid):
-    """
-    Check prime vertical radius on equator and poles
+    r"""
+    Check prime vertical radius on equator, poles and 45 degrees
+
+    The prime vertical radius can be also expressed in terms of the semi-major and
+    semi-minor axis:
+
+    .. math:
+
+        N(\phi) = \frac{a^2}{\sqrt{a^2 \cos^2 \phi + b^2 \sin^2 \phi}}
     """
     # Compute prime vertical radius on the equator and the poles
-    latitudes = np.array([0, 90, -90])
+    latitudes = np.array([0, 90, -90, 45])
     prime_vertical_radii = ellipsoid.prime_vertical_radius(
         np.sin(np.radians(latitudes))
     )
@@ -188,11 +195,15 @@ def test_prime_vertical_radius(ellipsoid):
     prime_vertical_radius_pole = (
         ellipsoid.semimajor_axis ** 2 / ellipsoid.semiminor_axis
     )
+    prime_vertical_radius_45 = ellipsoid.semimajor_axis ** 2 / np.sqrt(
+        0.5 * ellipsoid.semimajor_axis ** 2 + 0.5 * ellipsoid.semiminor_axis ** 2
+    )
     expected_pvr = np.array(
         [
             prime_vertical_radius_equator,
             prime_vertical_radius_pole,
             prime_vertical_radius_pole,
+            prime_vertical_radius_45,
         ]
     )
     # Compare calculated vs expected values

--- a/boule/tests/test_ellipsoid.py
+++ b/boule/tests/test_ellipsoid.py
@@ -171,3 +171,29 @@ def test_normal_gravity_non_zero_height(ellipsoid):
     assert gamma_pole < ellipsoid.normal_gravity(90, -1000)
     assert gamma_pole < ellipsoid.normal_gravity(-90, -1000)
     assert gamma_eq < ellipsoid.normal_gravity(0, -1000)
+
+
+@pytest.mark.parametrize("ellipsoid", ELLIPSOIDS, ids=ELLIPSOID_NAMES)
+def test_prime_vertical_radius(ellipsoid):
+    """
+    Check prime vertical radius on equator and poles
+    """
+    # Compute prime vertical radius on the equator and the poles
+    latitudes = np.array([0, 90, -90])
+    prime_vertical_radii = ellipsoid.prime_vertical_radius(
+        np.sin(np.radians(latitudes))
+    )
+    # Computed expected values
+    prime_vertical_radius_equator = ellipsoid.semimajor_axis
+    prime_vertical_radius_pole = (
+        ellipsoid.semimajor_axis ** 2 / ellipsoid.semiminor_axis
+    )
+    expected_pvr = np.array(
+        [
+            prime_vertical_radius_equator,
+            prime_vertical_radius_pole,
+            prime_vertical_radius_pole,
+        ]
+    )
+    # Compare calculated vs expected values
+    npt.assert_allclose(prime_vertical_radii, expected_pvr)


### PR DESCRIPTION
Add private method to `boule.Ellipsoid` for computing the prime vertical radius.
The definition of the prime vertical radius can be seen on [Vermeille (2002)](https://doi.org/10.1007/s00190-002-0273-6)  and [Vajda (2004)](https://d1wqtxts1xzle7.cloudfront.net/45194692/On_evaluation_of_Newton_integrals_in_geo20160429-31556-16b23iv.pdf?1461926098=&response-content-disposition=inline%3B+filename%3DOn_evaluation_of_Newton_integrals_in_geo.pdf&Expires=1594246043&Signature=G0FRusq9DVc1eSllnrFGZUufrskJdDQgXpOn8pzITqSQVvnwflK2a9nSZqUbfqD2msqsDEVbUiaNeUKEeXYentp3GiMmEXE~P-Dt9KddO0-AcaXf-WjTUWeJb5wmnFKFAFANWhNS4x9IlVY2NdqPP2U-Ide6KxA7yNGN-JhQ1i-OvQEG8dSAgvYJTDKhdodlWcLmn1zYtlDGtde3IMEWT2JpB-JzoXRF8aJbEMTKXEGvnb4FMgGxWsfsCmFry67Zu3pAebeRrvGhY-JYuODa2bGqr8nu8CyO0KuOV5eoVFLI2zFZWIXwDH1njr~2kLhvJwBMm9q4r7joTRAPvnmcbw__&Key-Pair-Id=APKAJLOHF5GGSLRBV4ZA).
It's usually symbolized with the letter N and depends on the geometry of the ellipsoid and it must be evaluated on a certain latitude angle.
We were already computing it for applying the geodetic to geodetic to spherical coordinate conversion.
It is also needed for computing the Euclidean distance between two points given in geodetic coordinates (see Vajda, 2004), feature that will be added after solving https://github.com/fatiando/harmonica/issues/154 .
In order to prevent rewriting the equation, it's better to have a private function inside `boule.Ellipsoid`.
The new method takes the precomputed sine of the latitude angle to make it more efficient.



**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
