### PR TITLE
Format the doc/conf.py file with Black

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ TESTDIR=tmp-test-dir-with-unique-name
 PYTEST_ARGS=--cov-config=../.coveragerc --cov-report=term-missing --cov=$(PROJECT) --doctest-modules --doctest-glob='*.rst' -v --pyargs
 LINT_FILES=setup.py $(PROJECT)
 BLACK_FILES=setup.py doc/conf.py $(PROJECT) tutorials
-FLAKE8_FILES=setup.py $(PROJECT)
+FLAKE8_FILES=setup.py doc/conf.py $(PROJECT)
 
 help:
 	@echo "Commands:"

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -38,7 +38,7 @@ sphinx_gallery_conf = {
     "examples_dirs": ["../tutorials"],
     # path where to save gallery generated examples
     "gallery_dirs": ["tutorials"],
-    "filename_pattern": "\.py",
+    "filename_pattern": r"\.py",
     # Remove the "Download all examples" button from the top level gallery
     "download_all_examples": False,
     # Sort gallery example by file name instead of number of lines (default)


### PR DESCRIPTION
Ran black on `doc/conf.py` and added it to the `black` and `flake8` runs
in the main Makefile.

Inspired on https://github.com/fatiando/rockhound/pull/87

<!--
Please describe changes proposed and WHY you made them. If fixing an issue,
include the text "Fixes #XXX" (replace XXX by the issue number. GitHub will
automatically close it when this gets merged.
-->





**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
