### PR TITLE
Add checks for ellipsoid parameters

### DIFF
--- a/boule/ellipsoid.py
+++ b/boule/ellipsoid.py
@@ -1,6 +1,7 @@
 """
 Module for defining and setting the reference ellipsoid.
 """
+import warnings
 import attr
 import numpy as np
 
@@ -75,6 +76,44 @@ class Ellipsoid:
     angular_velocity = attr.ib()
     long_name = attr.ib(default=None)
     reference = attr.ib(default=None)
+
+    @flattening.validator
+    def check_flattening(
+        self, flattening, value
+    ):  # pylint: disable=no-self-use,unused-argument
+        """
+        Check if flattening is between 0 and 1
+        """
+        if value < 0 or value >= 1:
+            raise ValueError(
+                "Invalid flattening '{}'. ".format(value)
+                + "Flattening should be greater or equal to zero and lower than 1."
+            )
+
+    @semimajor_axis.validator
+    def check_semimajor_axis(
+        self, semimajor_axis, value
+    ):  # pylint: disable=no-self-use,unused-argument
+        """
+        Check if semimajor_axis is positive
+        """
+        if not value > 0:
+            raise ValueError(
+                "Invalid semimajor_axis '{}'. ".format(value)
+                + "Semimajor axis should be greater than zero."
+            )
+
+    @geocentric_grav_const.validator
+    def check_geocentric_grav_const(
+        self, geocentric_grav_const, value
+    ):  # pylint: disable=no-self-use,unused-argument
+        """
+        Warn if geocentric_grav_const is negative
+        """
+        if value < 0:
+            warnings.warn(
+                "Received a negative geocentric_grav_const '{}'. ".format(value)
+            )
 
     @property
     def semiminor_axis(self):

--- a/boule/tests/test_ellipsoid.py
+++ b/boule/tests/test_ellipsoid.py
@@ -2,6 +2,7 @@
 """
 Test the base Ellipsoid class.
 """
+import warnings
 import pytest
 import numpy as np
 import numpy.testing as npt
@@ -23,6 +24,65 @@ def sphere():
         angular_velocity=0,
     )
     return ellipsoid
+
+
+def test_check_flattening():
+    """
+    Check if error is raised after invalid flattening
+    """
+    with pytest.raises(ValueError):
+        Ellipsoid(
+            name="negative_flattening",
+            semimajor_axis=1.0,
+            flattening=-1,
+            geocentric_grav_const=0,
+            angular_velocity=0,
+        )
+    with pytest.raises(ValueError):
+        Ellipsoid(
+            name="flattening_greater_than_one",
+            semimajor_axis=1.0,
+            flattening=1.5,
+            geocentric_grav_const=0,
+            angular_velocity=0,
+        )
+
+
+def test_check_semimajor_axis():
+    """
+    Check if error is raised after invalid semimajor_axis
+    """
+    with pytest.raises(ValueError):
+        Ellipsoid(
+            name="zero_semimajor_axis",
+            semimajor_axis=0,
+            flattening=0.1,
+            geocentric_grav_const=0,
+            angular_velocity=0,
+        )
+    with pytest.raises(ValueError):
+        Ellipsoid(
+            name="negative_semimajor_axis",
+            semimajor_axis=-1,
+            flattening=0.1,
+            geocentric_grav_const=0,
+            angular_velocity=0,
+        )
+
+
+def test_check_geocentric_grav_const():
+    """
+    Check if warn is raised after negative geocentric_grav_const
+    """
+    with warnings.catch_warnings(record=True) as warn:
+        Ellipsoid(
+            name="negative_gm",
+            semimajor_axis=1,
+            flattening=0.1,
+            geocentric_grav_const=-1,
+            angular_velocity=0,
+        )
+        assert len(warn) >= 1
 
 
 def test_geodetic_to_spherical_with_spherical_ellipsoid(sphere):


### PR DESCRIPTION
Add methods for validating ellipsoid parameters.
Raise error if flattening is negative or greater than 1.
Raise error if semimajor axis is not positive.
Raise warning if GM constant is negative.
Add tests functions for new features.

Fixes #43




**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
