### PR TITLE
Fix missing centrifugal term for sphere gravity at the equator

### DIFF
--- a/boule/sphere.py
+++ b/boule/sphere.py
@@ -138,7 +138,10 @@ class Sphere(Ellipsoid):
         Overrides the inherited method from :class:`boule.Ellipsoid` to avoid
         singularities due to zero flattening.
         """
-        return self._gravity_on_surface
+        return (
+            self.geocentric_grav_const / self.radius ** 2
+            - self.radius * self.angular_velocity ** 2
+        )
 
     @property
     def gravity_pole(self):
@@ -147,15 +150,5 @@ class Sphere(Ellipsoid):
 
         Overrides the inherited method from :class:`boule.Ellipsoid` to avoid
         singularities due to zero flattening.
-        """
-        return self._gravity_on_surface
-
-    @property
-    def _gravity_on_surface(self):
-        """
-        Compute norm of the gravity vector on the surface of the sphere [m/s^2]
-
-        Due to rotational symmetry, the norm of the gravity vector is the same
-        on every point of the surface.
         """
         return self.geocentric_grav_const / self.radius ** 2

--- a/boule/tests/test_sphere.py
+++ b/boule/tests/test_sphere.py
@@ -100,13 +100,18 @@ def test_geocentric_radius(sphere):
         )
 
 
-def test_gravity_on_equator_and_poles(sphere):
+def test_normal_gravity_pole_equator(sphere):
     """
-    Check gravity on equator and poles
+    Compare normal gravity values at pole and equator
     """
-    expected_value = sphere.geocentric_grav_const / sphere.radius ** 2
-    npt.assert_allclose(sphere.gravity_pole, expected_value)
-    npt.assert_allclose(sphere.gravity_equator, expected_value)
+    rtol = 1e-10
+    height = 0
+    # Convert gamma to mGal
+    gamma_pole = sphere.gravity_pole * 1e5
+    gamma_eq = sphere.gravity_equator * 1e5
+    npt.assert_allclose(gamma_pole, sphere.normal_gravity(-90, height), rtol=rtol)
+    npt.assert_allclose(gamma_pole, sphere.normal_gravity(90, height), rtol=rtol)
+    npt.assert_allclose(gamma_eq, sphere.normal_gravity(0, height), rtol=rtol)
 
 
 def test_normal_gravity_no_rotation():


### PR DESCRIPTION
Fix the method that computes the norm of the gravity acceleration vector
on the equator of a sphere. The method used to return only the
gravitational attraction term, without the centrifugal acceleration
term. Add the additional term and update the test function, which now
compares gravity on poles and equator with the normal gravity formula.


**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
