### PR TITLE
Stop saving the docs HTML as build artifacts

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -126,14 +126,6 @@ jobs:
       - name: Build the documentation
         run: make -C doc clean all
 
-      # Store the docs as a build artifact on GitHub so we can check it if
-      # needed.
-      - name: Upload HTML documentation as an artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: docs-${{ matrix.os }}-${{ matrix.python }}${{ matrix.dependencies }}-{{ github.sha }}
-          path: doc/_build/html
-
       - name: Convert coverage report to XML for codecov
         run: coverage xml
 


### PR DESCRIPTION
It's a bit wasteful to store all this data that we will very likely
never use (downloading the cached page displaying them locally requires
a lot of clicking). So we might as well leave this out for now.

<!--
Please describe changes proposed and WHY you made them. If fixing an issue,
include the text "Fixes #XXX" (replace XXX by the issue number. GitHub will
automatically close it when this gets merged.
-->





**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
