### PR TITLE
Revert change to "sed" command in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,11 +64,10 @@ jobs:
 
       - name: Build source and wheel distributions
         run: |
-          # Change the versioneer format to "pre" so that the commit hash isn't
-          # included (PyPI doesn't allow it). Can't do this permanently because
-          # we rely the hash to indicate to the tests that this is a local
-          # verison instead of a published version.
-          sed --in-place "s/pep440/pep440-pre/g" setup.cfg
+          # Change setuptools-scm local_scheme to "no-local-version" so the
+          # local part of the version isn't included, making the version string
+          # compatible with Test PyPI.
+          sed --in-place "s/node-and-date/no-local-version/g" setup.py
           nox -s build -- list-packages
           echo ""
           echo "Generated files:"


### PR DESCRIPTION
In #59, we inadvertently reverted the `sed` command in the `deploy`
workflow to the versioneer version. This reintroduces the correct
command from #61.

<!--
Please describe changes proposed and WHY you made them. If fixing an issue,
include the text "Fixes #XXX" (replace XXX by the issue number. GitHub will
automatically close it when this gets merged.
-->





**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
