### PR TITLE
Refactor workflows to separate building the docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,14 +1,16 @@
-# Configuration for publishing archives to PyPI and documentation pages to
-# GitHub Pages using GitHub Actions.
+# Build the documentation and deploy to GitHub Pages using GitHub Actions.
 #
 # NOTE: Pin actions to a specific commit to avoid having the authentication
 # token stolen if the Action is compromised. See the comments and links here:
 # https://github.com/pypa/gh-action-pypi-publish/issues/27
 #
-name: deploy
+name: docs
 
-# Only run for pushes to the master branch and releases.
+# Only build PRs, the master branch, and releases. Pushes to branches will only
+# be built when a PR is opened. This avoids duplicated buids in PRs comming
+# from branches in the origin repository (1 for PR and 1 for push).
 on:
+  pull_request:
   push:
     branches:
       - master
@@ -25,13 +27,8 @@ defaults:
     shell: bash
 
 jobs:
-  #############################################################################
-  # Publish built wheels and source archives to PyPI and test PyPI
-  pypi:
-    name: PyPI
+  build:
     runs-on: ubuntu-latest
-    # Only publish from the origin repository, not forks
-    if: github.repository == 'fatiando/boule'
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE
@@ -40,73 +37,6 @@ jobs:
         with:
           # Need to fetch more than the last commit so that versioneer can
           # create the correct version string. If the number of commits since
-          # the last release is greater than this, the version will still be wrong.
-          # Increase if necessary.
-          fetch-depth: 100
-          # The GitHub token is preserved by default but this job doesn't need
-          # to be able to push to GitHub.
-          persist-credentials: false
-
-      # Need the tags so that setuptools-scm can form a valid version number
-      - name: Fetch git tags
-        run: git fetch origin 'refs/tags/*:refs/tags/*'
-
-      - name: Setup Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: "3.8"
-
-      - name: Install requirements
-        run: python -m pip install nox
-
-      - name: List installed packages
-        run: python -m pip freeze
-
-      - name: Build source and wheel distributions
-        run: |
-          # Change setuptools-scm local_scheme to "no-local-version" so the
-          # local part of the version isn't included, making the version string
-          # compatible with Test PyPI.
-          sed --in-place "s/node-and-date/no-local-version/g" setup.py
-          nox -s build -- list-packages
-          echo ""
-          echo "Generated files:"
-          ls -lh dist/
-
-      - name: Publish to Test PyPI
-        if: success()
-        uses: pypa/gh-action-pypi-publish@bce3b74dbf8cc32833ffba9d15f83425c1a736e0
-        with:
-          user: __token__
-          password: ${{ secrets.TEST_PYPI_TOKEN}}
-          repository_url: https://test.pypi.org/legacy/
-          # Allow existing releases on test PyPI without errors.
-          # NOT TO BE USED in PyPI!
-          skip_existing: true
-
-      - name: Publish to PyPI
-        # Only publish to PyPI when a release triggers the build
-        if: success() && github.event_name == 'release'
-        uses: pypa/gh-action-pypi-publish@bce3b74dbf8cc32833ffba9d15f83425c1a736e0
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_TOKEN}}
-
-  #############################################################################
-  # Publish the documentation to gh-pages
-  docs:
-    name: docs
-    runs-on: ubuntu-latest
-    # Only publish from the origin repository, not forks
-    if: github.repository == 'fatiando/boule'
-
-    steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          # Need to fetch more than the last commit so that setuptools_scm can
-          # create the correct version string. If the number of commits since
           # the last release is greater than this, the version still be wrong.
           # Increase if necessary.
           fetch-depth: 100
@@ -114,7 +44,7 @@ jobs:
           # to be able to push to GitHub.
           persist-credentials: false
 
-      # Need the tags so that versioneer can form a valid version number
+      # Need the tags so that setuptools_scm can form a valid version number
       - name: Fetch git tags
         run: git fetch origin 'refs/tags/*:refs/tags/*'
 
@@ -128,6 +58,29 @@ jobs:
 
       - name: Build the documentation
         run: nox -s docs -- list-packages
+
+      # Store the docs as a build artifact so we can deploy it later
+      - name: Upload HTML documentation as an artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: docs-${{ github.sha }}
+          path: doc/_build/html
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.event_name == 'release' || github.event_name == 'push'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      # Fetch the built docs from the "build" job
+      - name: Download HTML documentation artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: docs-${{ github.sha }}
+          path: doc/_build/html
 
       - name: Checkout the gh-pages branch in a separate folder
         uses: actions/checkout@28c7f3d2b5162b5ddd3dfd9a45aa55eaf396478b

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,9 +35,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
         with:
-          # Need to fetch more than the last commit so that versioneer can
+          # Need to fetch more than the last commit so that setuptools-scm can
           # create the correct version string. If the number of commits since
-          # the last release is greater than this, the version still be wrong.
+          # the last release is greater than this, the version will still be wrong.
           # Increase if necessary.
           fetch-depth: 100
           # The GitHub token is preserved by default but this job doesn't need

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,0 +1,86 @@
+# Publish archives to PyPI and TestPyPI using GitHub Actions.
+#
+# NOTE: Pin actions to a specific commit to avoid having the authentication
+# token stolen if the Action is compromised. See the comments and links here:
+# https://github.com/pypa/gh-action-pypi-publish/issues/27
+#
+name: pypi
+
+# Only run for pushes to the master branch and releases.
+on:
+  push:
+    branches:
+      - master
+  release:
+    types:
+      - published
+
+# Use bash by default in all jobs
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  #############################################################################
+  # Publish built wheels and source archives to PyPI and test PyPI
+  publish:
+    runs-on: ubuntu-latest
+    # Only publish from the origin repository, not forks
+    if: github.repository_owner == 'fatiando'
+
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          # Need to fetch more than the last commit so that setuptools_scm can
+          # create the correct version string. If the number of commits since
+          # the last release is greater than this, the version will still be
+          # wrong. Increase if necessary.
+          fetch-depth: 100
+          # The GitHub token is preserved by default but this job doesn't need
+          # to be able to push to GitHub.
+          persist-credentials: false
+
+      # Need the tags so that setuptools_scm can form a valid version number
+      - name: Fetch git tags
+        run: git fetch origin 'refs/tags/*:refs/tags/*'
+
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.8"
+
+      - name: Install requirements
+        run: python -m pip install nox twine
+
+      - name: Build source and wheel distributions
+        run: |
+          # Change setuptools-scm local_scheme to "no-local-version" so the
+          # local part of the version isn't included, making the version string
+          # compatible with Test PyPI.
+          sed --in-place "s/node-and-date/no-local-version/g" setup.py
+          # Build source and wheel packages
+          nox -s build -- list-packages
+          echo ""
+          echo "Generated files:"
+          ls -lh dist/
+
+      - name: Publish to Test PyPI
+        if: success()
+        uses: pypa/gh-action-pypi-publish@bce3b74dbf8cc32833ffba9d15f83425c1a736e0
+        with:
+          user: __token__
+          password: ${{ secrets.TEST_PYPI_TOKEN}}
+          repository_url: https://test.pypi.org/legacy/
+          # Allow existing releases on test PyPI without errors.
+          # NOT TO BE USED in PyPI!
+          skip_existing: true
+
+      - name: Publish to PyPI
+        # Only publish to PyPI when a release triggers the build
+        if: success() && github.event_name == 'release'
+        uses: pypa/gh-action-pypi-publish@bce3b74dbf8cc32833ffba9d15f83425c1a736e0
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_TOKEN}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-# Configuration for testing and deploying with GitHub Actions
+# Configuration for running tests with GitHub Actions
 #
 # NOTE: Pin actions to a specific commit to avoid having the authentication
 # token stolen if the Action is compromised. See the comments and links here:
@@ -27,8 +27,6 @@ defaults:
     shell: bash
 
 jobs:
-  #############################################################################
-  # Run tests, build the docs, and deploy if needed
   test:
     name: ${{ matrix.os }} py${{ matrix.python }}
     runs-on: ${{ matrix.os }}-latest
@@ -57,7 +55,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
         with:
-          # Need to fetch more than the last commit so that setuptools-scm can
+          # Need to fetch more than the last commit so that setuptools_scm can
           # create the correct version string. If the number of commits since
           # the last release is greater than this, the version still be wrong.
           # Increase if necessary.
@@ -66,7 +64,7 @@ jobs:
           # to be able to push to GitHub.
           persist-credentials: false
 
-      # Need the tags so that setuptools-scm can form a valid version number
+      # Need the tags so that setuptools_scm can form a valid version number
       - name: Fetch git tags
         run: git fetch origin 'refs/tags/*:refs/tags/*'
 
@@ -80,9 +78,6 @@ jobs:
 
       - name: Run the tests
         run: nox -s test-${{ matrix.python }} -- list-packages
-
-      - name: Build the documentation
-        run: nox -s docs -- list-packages
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1


### PR DESCRIPTION
Instead of running the docs build every time, leave it to one workflow
which can then reuse the HTML artifacts to deploy. Separate the PyPI
deploy in a separate workflow as well.

<!--
Please describe changes proposed and WHY you made them. If fixing an issue,
include the text "Fixes #XXX" (replace XXX by the issue number. GitHub will
automatically close it when this gets merged.
-->





**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
