### PR TITLE
Add a warning if a point is outside the ellipsoid

### DIFF
--- a/boule/ellipsoid.py
+++ b/boule/ellipsoid.py
@@ -443,6 +443,15 @@ class Ellipsoid:
             The normal gravity in mGal.
 
         """
+        """
+        Warn if given point is not outside the ellipsoid
+        
+        """
+        if height < 0:
+            warn(f"The normal gravity formulas used are valid for points outside
+            the ellipsoid, height must be major or equal to zero")
+        
+
         sinlat = np.sin(np.deg2rad(latitude))
         coslat = np.sqrt(1 - sinlat ** 2)
         # The terms below follow the variable names from Li and Goetze (2001)

--- a/boule/sphere.py
+++ b/boule/sphere.py
@@ -178,6 +178,9 @@ class Sphere(Ellipsoid):
             The normal gravity in mGal.
 
         """
+        if height < 0:
+        warn(f"The normal gravity formulas used are valid for points outside
+        the ellipsoid, height must be major or equal to zero")
         radial_distance = self.radius + height
         gravity_acceleration = self.geocentric_grav_const / (radial_distance) ** 2
         return 1e5 * np.sqrt(


### PR DESCRIPTION
Add warning for the normal gravity formula when the height is negative
Issue #44 
<!--
Please describe changes proposed and WHY you made them. If fixing an issue,
include the text "Fixes #XXX" (replace XXX by the issue number. GitHub will
automatically close it when this gets merged.
-->





**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
