### PR TITLE
Add option to return normal gravity in SI units

### DIFF
--- a/boule/ellipsoid.py
+++ b/boule/ellipsoid.py
@@ -436,7 +436,7 @@ class Ellipsoid:
         height : float or array
             The ellipsoidal (geometric) height of computation the point (in
             meters).
-        si_units : bool 
+        si_units : bool
             Return the value in mGal (False, default) or SI units (True)
 
         Returns

--- a/boule/ellipsoid.py
+++ b/boule/ellipsoid.py
@@ -419,7 +419,7 @@ class Ellipsoid:
         big_d = k * radius * cos_latitude / (k + self.first_eccentricity ** 2)
         return k, big_z, big_d
 
-    def normal_gravity(self, latitude, height):
+    def normal_gravity(self, latitude, height, si_units=False):
         """
         Calculate normal gravity at any latitude and height.
 
@@ -436,6 +436,8 @@ class Ellipsoid:
         height : float or array
             The ellipsoidal (geometric) height of computation the point (in
             meters).
+        si_units : bool 
+            Return the value in mGal (False, default) or SI units (True)
 
         Returns
         -------
@@ -460,6 +462,8 @@ class Ellipsoid:
         )
         term3 = -cosbeta_l2 * b_l * self.angular_velocity ** 2
         gamma = (term1 + term2 + term3) / big_w
+        if si_units:
+            return gamma
         # Convert gamma from SI to mGal
         return gamma * 1e5
 

--- a/boule/ellipsoid.py
+++ b/boule/ellipsoid.py
@@ -419,7 +419,9 @@ class Ellipsoid:
         big_d = k * radius * cos_latitude / (k + self.first_eccentricity ** 2)
         return k, big_z, big_d
 
-    def normal_gravity(self, latitude, height, si_units=False):
+    def normal_gravity(
+        self, latitude, height, si_units=False
+    ):  # pylint: disable=too-many-locals
         """
         Calculate normal gravity at any latitude and height.
 

--- a/boule/sphere.py
+++ b/boule/sphere.py
@@ -86,6 +86,13 @@ class Sphere(Ellipsoid):
     >>> print("{:.2f}".format(sphere.normal_gravity(latitude=90, height=0)))
     200000.00
 
+    The flag si_units will return the Normal gravity in m/s².
+
+    >>> print("{:.2f}".format(sphere.normal_gravity(latitude=0, height=0, si_units=True)))
+    1.75
+    >>> print("{:.2f}".format(sphere.normal_gravity(latitude=90, height=0, si_units=True)))
+    2.00
+
     The flattening and eccentricities will all be zero:
 
     >>> print("{:.2f}".format(sphere.flattening))

--- a/boule/sphere.py
+++ b/boule/sphere.py
@@ -171,7 +171,7 @@ class Sphere(Ellipsoid):
         height : float or array
             The height (above the surface of the sphere) of the computation
             point (in meters).
-        si_units : bool 
+        si_units : bool
             Return the value in mGal (False, default) or SI units (True)
 
         Returns

--- a/boule/sphere.py
+++ b/boule/sphere.py
@@ -136,7 +136,7 @@ class Sphere(Ellipsoid):
         if value < 0:
             warn(f"The geocentric gravitational constant is negative: '{value}'")
 
-    def normal_gravity(self, latitude, height):
+    def normal_gravity(self, latitude, height, si_units=False):
         r"""
         Calculate normal gravity at any latitude and height
 
@@ -171,6 +171,8 @@ class Sphere(Ellipsoid):
         height : float or array
             The height (above the surface of the sphere) of the computation
             point (in meters).
+        si_units : bool 
+            Return the value in mGal (False, default) or SI units (True)
 
         Returns
         -------
@@ -180,7 +182,7 @@ class Sphere(Ellipsoid):
         """
         radial_distance = self.radius + height
         gravity_acceleration = self.geocentric_grav_const / (radial_distance) ** 2
-        return 1e5 * np.sqrt(
+        gamma = np.sqrt(
             gravity_acceleration ** 2
             + (self.angular_velocity ** 2 * radial_distance - 2 * gravity_acceleration)
             * self.angular_velocity ** 2
@@ -188,6 +190,10 @@ class Sphere(Ellipsoid):
             # replace cos^2 with (1 - sin^2) for more accurate results on the pole
             * (1 - np.sin(np.radians(latitude)) ** 2)
         )
+        if si_units:
+            return gamma
+        # Convert gamma from SI to mGal
+        return gamma * 1e5
 
     @property
     def gravity_equator(self):

--- a/boule/tests/test_ellipsoid.py
+++ b/boule/tests/test_ellipsoid.py
@@ -188,8 +188,9 @@ def test_normal_gravity_pole_equator(ellipsoid):
     npt.assert_allclose(gamma_eq, ellipsoid.normal_gravity(0, height), rtol=rtol)
 
 
+@pytest.mark.parametrize("si_units", [False, True], ids=["mGal", "SI"])
 @pytest.mark.parametrize("ellipsoid", ELLIPSOIDS, ids=ELLIPSOID_NAMES)
-def test_normal_gravity_arrays(ellipsoid):
+def test_normal_gravity_arrays(ellipsoid, si_units):
     "Compare normal gravity passing arrays as arguments instead of floats"
     rtol = 1e-10
     heights = np.zeros(3)
@@ -198,21 +199,12 @@ def test_normal_gravity_arrays(ellipsoid):
         [ellipsoid.gravity_pole, ellipsoid.gravity_pole, ellipsoid.gravity_equator]
     )
     # Convert gammas to mGal
-    gammas *= 1e5
-    npt.assert_allclose(gammas, ellipsoid.normal_gravity(latitudes, heights), rtol=rtol)
-
-
-@pytest.mark.parametrize("ellipsoid", ELLIPSOIDS, ids=ELLIPSOID_NAMES)
-def test_normal_gravity_siunits_arrays(ellipsoid):
-    "Compare normal gravity passing arrays as arguments instead of floats and returning values in SI units"
-    rtol = 1e-10
-    heights = np.zeros(3)
-    latitudes = np.array([-90, 90, 0])
-    gammas = np.array(
-        [ellipsoid.gravity_pole, ellipsoid.gravity_pole, ellipsoid.gravity_equator]
-    )
+    if not si_units:
+        gammas *= 1e5
     npt.assert_allclose(
-        gammas, ellipsoid.normal_gravity(latitudes, heights, si_units=True), rtol=rtol
+        gammas,
+        ellipsoid.normal_gravity(latitudes, heights, si_units=si_units),
+        rtol=rtol,
     )
 
 

--- a/boule/tests/test_ellipsoid.py
+++ b/boule/tests/test_ellipsoid.py
@@ -203,6 +203,18 @@ def test_normal_gravity_arrays(ellipsoid):
 
 
 @pytest.mark.parametrize("ellipsoid", ELLIPSOIDS, ids=ELLIPSOID_NAMES)
+def test_normal_gravity_siunits_arrays(ellipsoid):
+    "Compare normal gravity passing arrays as arguments instead of floats and returning values in SI units"
+    rtol = 1e-10
+    heights = np.zeros(3)
+    latitudes = np.array([-90, 90, 0])
+    gammas = np.array(
+        [ellipsoid.gravity_pole, ellipsoid.gravity_pole, ellipsoid.gravity_equator]
+    )
+    npt.assert_allclose(gammas, ellipsoid.normal_gravity(latitudes, heights, si_units=True), rtol=rtol)
+
+
+@pytest.mark.parametrize("ellipsoid", ELLIPSOIDS, ids=ELLIPSOID_NAMES)
 def test_normal_gravity_non_zero_height(ellipsoid):
     "Check consistency of normal gravity above and below the ellipsoid."
     # Convert gamma to mGal

--- a/boule/tests/test_ellipsoid.py
+++ b/boule/tests/test_ellipsoid.py
@@ -211,7 +211,9 @@ def test_normal_gravity_siunits_arrays(ellipsoid):
     gammas = np.array(
         [ellipsoid.gravity_pole, ellipsoid.gravity_pole, ellipsoid.gravity_equator]
     )
-    npt.assert_allclose(gammas, ellipsoid.normal_gravity(latitudes, heights, si_units=True), rtol=rtol)
+    npt.assert_allclose(
+        gammas, ellipsoid.normal_gravity(latitudes, heights, si_units=True), rtol=rtol
+    )
 
 
 @pytest.mark.parametrize("ellipsoid", ELLIPSOIDS, ids=ELLIPSOID_NAMES)

--- a/boule/tests/test_sphere.py
+++ b/boule/tests/test_sphere.py
@@ -152,6 +152,18 @@ def test_normal_gravity_pole_equator(sphere):
     npt.assert_allclose(gamma_pole, sphere.normal_gravity(90, height), rtol=rtol)
     npt.assert_allclose(gamma_eq, sphere.normal_gravity(0, height), rtol=rtol)
 
+def test_normal_gravity_si_pole_equator(sphere):
+    """
+    Compare normal gravity values at pole and equator
+    """
+    rtol = 1e-10
+    height = 0
+    # Get gammas in SI Units
+    gamma_pole = sphere.gravity_pole 
+    gamma_eq = sphere.gravity_equator 
+    npt.assert_allclose(gamma_pole, sphere.normal_gravity(-90, height, si_units=True), rtol=rtol)
+    npt.assert_allclose(gamma_pole, sphere.normal_gravity(90, height, si_units=True), rtol=rtol)
+    npt.assert_allclose(gamma_eq, sphere.normal_gravity(0, height, si_units=True), rtol=rtol)
 
 def test_normal_gravity_no_rotation():
     """

--- a/boule/tests/test_sphere.py
+++ b/boule/tests/test_sphere.py
@@ -139,37 +139,27 @@ def test_geocentric_radius(sphere):
         )
 
 
-def test_normal_gravity_pole_equator(sphere):
+@pytest.mark.parametrize("si_units", [False, True], ids=["mGal", "SI"])
+def test_normal_gravity_pole_equator(sphere, si_units):
     """
     Compare normal gravity values at pole and equator
     """
     rtol = 1e-10
     height = 0
-    # Convert gamma to mGal
-    gamma_pole = sphere.gravity_pole * 1e5
-    gamma_eq = sphere.gravity_equator * 1e5
-    npt.assert_allclose(gamma_pole, sphere.normal_gravity(-90, height), rtol=rtol)
-    npt.assert_allclose(gamma_pole, sphere.normal_gravity(90, height), rtol=rtol)
-    npt.assert_allclose(gamma_eq, sphere.normal_gravity(0, height), rtol=rtol)
-
-
-def test_normal_gravity_si_pole_equator(sphere):
-    """
-    Compare normal gravity values at pole and equator
-    """
-    rtol = 1e-10
-    height = 0
-    # Get gammas in SI Units
     gamma_pole = sphere.gravity_pole
     gamma_eq = sphere.gravity_equator
+    if not si_units:
+        # Convert gamma to mGal
+        gamma_pole = sphere.gravity_pole * 1e5
+        gamma_eq = sphere.gravity_equator * 1e5
     npt.assert_allclose(
-        gamma_pole, sphere.normal_gravity(-90, height, si_units=True), rtol=rtol
+        gamma_pole, sphere.normal_gravity(-90, height, si_units=si_units), rtol=rtol
     )
     npt.assert_allclose(
-        gamma_pole, sphere.normal_gravity(90, height, si_units=True), rtol=rtol
+        gamma_pole, sphere.normal_gravity(90, height, si_units=si_units), rtol=rtol
     )
     npt.assert_allclose(
-        gamma_eq, sphere.normal_gravity(0, height, si_units=True), rtol=rtol
+        gamma_eq, sphere.normal_gravity(0, height, si_units=si_units), rtol=rtol
     )
 
 

--- a/boule/tests/test_sphere.py
+++ b/boule/tests/test_sphere.py
@@ -152,6 +152,7 @@ def test_normal_gravity_pole_equator(sphere):
     npt.assert_allclose(gamma_pole, sphere.normal_gravity(90, height), rtol=rtol)
     npt.assert_allclose(gamma_eq, sphere.normal_gravity(0, height), rtol=rtol)
 
+
 def test_normal_gravity_si_pole_equator(sphere):
     """
     Compare normal gravity values at pole and equator
@@ -159,11 +160,18 @@ def test_normal_gravity_si_pole_equator(sphere):
     rtol = 1e-10
     height = 0
     # Get gammas in SI Units
-    gamma_pole = sphere.gravity_pole 
-    gamma_eq = sphere.gravity_equator 
-    npt.assert_allclose(gamma_pole, sphere.normal_gravity(-90, height, si_units=True), rtol=rtol)
-    npt.assert_allclose(gamma_pole, sphere.normal_gravity(90, height, si_units=True), rtol=rtol)
-    npt.assert_allclose(gamma_eq, sphere.normal_gravity(0, height, si_units=True), rtol=rtol)
+    gamma_pole = sphere.gravity_pole
+    gamma_eq = sphere.gravity_equator
+    npt.assert_allclose(
+        gamma_pole, sphere.normal_gravity(-90, height, si_units=True), rtol=rtol
+    )
+    npt.assert_allclose(
+        gamma_pole, sphere.normal_gravity(90, height, si_units=True), rtol=rtol
+    )
+    npt.assert_allclose(
+        gamma_eq, sphere.normal_gravity(0, height, si_units=True), rtol=rtol
+    )
+
 
 def test_normal_gravity_no_rotation():
     """


### PR DESCRIPTION
This PR adds an option to return gamma in SI units for the normal_gravity method in both the ellipsoid and sphere classes as per #46 .
I have included an example in the sphere docstring and added tests for both classes.




**Reminders**:

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [x] Add tests for new features or tests that would have caught the bug that you're fixing.
- [x] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [x] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [x] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
