### PR TITLE
Add support for Python 3.9 and 3.10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, macos, windows]
-        python: [3.6, 3.7, 3.8]
+        python: ["3.6", "3.7", "3.8", "3.9", "3.10-dev"]
     env:
       # Used to tag codecov submissions
       OS: ${{ matrix.os }}
@@ -77,7 +77,10 @@ jobs:
         run: python -m pip install nox
 
       - name: Run the tests
-        run: nox -s test-${{ matrix.python }} -- list-packages
+        # Strip any "-dev" suffix
+        run: |
+          target=$(echo ${{ matrix.python }} | sed -e "s/-dev$//")
+          nox -s test-${target} -- list-packages
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,10 @@ jobs:
       matrix:
         os: [ubuntu, macos, windows]
         python: ["3.6", "3.7", "3.8", "3.9", "3.10-dev"]
+        # Remove when binary wheels available:
+        exclude:
+          - os: macos
+            python: "3.10-dev"
     env:
       # Used to tag codecov submissions
       OS: ${{ matrix.os }}

--- a/noxfile.py
+++ b/noxfile.py
@@ -45,7 +45,7 @@ NOX_ARGS = ["skip-install", "list-packages", "show"]
 
 
 PACKAGE = "boule"
-PYTHON_VERSIONS = ["3.9", "3.8", "3.7", "3.6"]
+PYTHON_VERSIONS = ["3.10", "3.9", "3.8", "3.7", "3.6"]
 DOCS = Path("doc")
 REQUIREMENTS = {
     "run": "requirements.txt",

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,8 @@ CLASSIFIERS = [
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
     "License :: OSI Approved :: {}".format(LICENSE),
 ]
 PLATFORMS = "Any"


### PR DESCRIPTION
<!--
Please describe changes proposed and WHY you made them. If fixing an issue,
include the text "Fixes #XXX" (replace XXX by the issue number. GitHub will
automatically close it when this gets merged.
-->

Fixes https://github.com/fatiando/boule/issues/85.

Includes and closes #86.

Related to fatiando/maintenance#15

Skip macOS as it fails building NumPy from source. Can be unexcluded when NumPy has released wheels for macOS.


**Reminders**:

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [n/a] Add tests for new features or tests that would have caught the bug that you're fixing.
- [n/a] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [n/a] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [n/a] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [x] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
