### PR TITLE
Fix version display in the HTML title

### DIFF
--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -21,6 +21,6 @@
     {% if title == '' or title == 'Home' %}
         <title>{{ docstitle|striptags|e }}</title>
     {% else %}
-        <title>{{ title|striptags|e }}{{ titlesuffix }}</title>
+        <title>{{ title|striptags|e }} | {{ docstitle|striptags|e }}</title>
     {% endif %}
 {% endblock %}


### PR DESCRIPTION
Forgot to remove the tags when including the version number in the HTML
title.

<!--
Please describe changes proposed and WHY you made them. If fixing an issue,
include the text "Fixes #XXX" (replace XXX by the issue number. GitHub will
automatically close it when this gets merged.
-->





**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
