### PR TITLE
Specify oldest supported version of dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
   #############################################################################
   # Run tests and upload to codecov
   test:
-    name: ${{ matrix.os }} python=${{ matrix.python }}
+    name: ${{ matrix.os }} python=${{ matrix.python }} dependencies=${{ matrix.dependencies }}
     runs-on: ${{ matrix.os }}-latest
     strategy:
       # Otherwise, the workflow would stop if a single job fails. We want to
@@ -40,6 +40,7 @@ jobs:
       matrix:
         os: [ubuntu, macos, windows]
         python: ["3.6", "3.10"]
+        dependencies: [latest, oldest]
     env:
       REQUIREMENTS: env/requirements-build.txt env/requirements-test.txt
       # Used to tag codecov submissions

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, macos, windows]
-        python: ["3.7", "3.10"]
+        python: ["3.6", "3.10"]
         dependencies: [latest, oldest]
     env:
       REQUIREMENTS: env/requirements-build.txt env/requirements-test.txt
@@ -74,7 +74,7 @@ jobs:
         run: git fetch origin 'refs/tags/*:refs/tags/*'
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, macos, windows]
-        python: ["3.6", "3.10"]
+        python: ["3.7", "3.10"]
         dependencies: [latest, oldest]
     env:
       REQUIREMENTS: env/requirements-build.txt env/requirements-test.txt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
         include:
           - python: "3.6"
             dependencies: oldest
-          - python: "3.10":
+          - python: "3.10"
             dependencies: latest
     env:
       REQUIREMENTS: env/requirements-build.txt env/requirements-test.txt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,11 @@ jobs:
       matrix:
         os: [ubuntu, macos, windows]
         python: ["3.6", "3.10"]
-        dependencies: [latest, oldest]
+        include:
+          - python: "3.6"
+            dependencies: oldest
+          - python: "3.10":
+            dependencies: latest
     env:
       REQUIREMENTS: env/requirements-build.txt env/requirements-test.txt
       # Used to tag codecov submissions

--- a/doc/compatibility.rst
+++ b/doc/compatibility.rst
@@ -1,0 +1,64 @@
+.. _compatibility:
+
+Version compatibility
+=====================
+
+Boule version compatibility
+---------------------------
+
+Boule uses `semantic versioning <https://semver.org/>`__ (i.e.,
+``MAJOR.MINOR.BUGFIX`` format).
+
+* Major releases mean that backwards incompatible changes were made.
+  Upgrading will require users to change their code.
+* Minor releases add new features/data without changing existing functionality.
+  Users can upgrade minor versions without changing their code.
+* Bug fix releases fix errors in a previous release without adding new
+  functionality. Users can upgrade minor versions without changing their code.
+
+We will add ``FutureWarning`` messages about deprecations ahead of making any
+breaking changes to give users a chance to upgrade.
+
+.. warning::
+
+    The above does not apply to versions < ``1.0.0``. All ``0.*`` versions may
+    deprecate, remove, or change functionality between releases. Proper
+    warnings will be raised and any breaking changes will be marked as such in
+    the :ref:`changes`.
+
+.. _dependency-versions:
+
+Supported dependency versions
+-----------------------------
+
+Boule follows the recommendations in
+`NEP29 <https://numpy.org/neps/nep-0029-deprecation_policy.html>`__ for setting
+the minimum required version of our dependencies.
+In short, we support **all minor releases of our dependencies from the previous
+24 months** before a Boule release with a minimum of 2 minor releases.
+
+We follow this guidance conservatively and won't require newer versions if the
+older ones are still working without causing problems.
+Whenever support for a version is dropped, we will include a note in the
+:ref:`changes`.
+
+.. note::
+
+    This was introduced in Boule v0.4.0.
+
+
+.. _python-versions:
+
+Supported Python versions
+-------------------------
+
+If you require support for older Python versions, please pin Boule to the
+following releases to ensure compatibility:
+
+.. list-table::
+    :widths: 40 60
+
+    * - **Python version**
+      - **Last compatible release**
+    * - 3.6
+      - 0.4.0

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -53,6 +53,7 @@
     :caption: Reference
 
     api/index.rst
+    compatibility.rst
     citing.rst
     changes.rst
     references.rst

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ project_urls =
 [options]
 zip_safe = True
 packages = find:
-python_requires = >=3.6
+python_requires = >=3.7
 install_requires =
     numpy>=1.19
     attrs>=19.3.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ project_urls =
 [options]
 zip_safe = True
 packages = find:
-python_requires = >=3.7
+python_requires = >=3.6
 install_requires =
     numpy>=1.19
     attrs>=19.3.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,8 +40,8 @@ zip_safe = True
 packages = find:
 python_requires = >=3.6
 install_requires =
-    numpy
-    attrs
+    numpy>=1.19
+    attrs>=19.3.0
 
 [flake8]
 max-line-length = 88


### PR DESCRIPTION
<!--
Thank you for contributing a pull request! Please ensure you have taken a look 
at the CONTRIBUTING.md file in this repository (if available) and the general 
guidelines at https://github.com/fatiando/community/blob/main/CONTRIBUTING.md
-->
**Description**
<!--
Please describe changes proposed and WHY you made them.
-->

Following the guidance in fatiando/community#40 and NEP29, support all 
minor versions from the past 24 months. This means numpy >= 1.19
and attrs >= 19.3. Add CI tests for the oldest versions but test only 
oldest supported versions with the oldest Python and vice-versa because
numpy doesn't supply wheels for old versions on new Python. It also
saves CI compute time and should be more than enough of a safeguard.

**Relevant issues/PRs**
<!--
Link to relevant issues/PRs. Example: "Fixes #1234" or "See also #345"
Use keywords (e.g., Fixes, Closes) to create the links and automatically
close issues when this PR is merged. 
See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Related to fatiando/community#40