### PR TITLE
Fix license link + compatibility warning in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,19 @@ Some examples of where Boule can be applied:
   derivatives) of ellipsoids in closed form.
 * Include a range ellipsoids for the Earth and other planetary bodies.
 
+## Project status
+
+**Boule is ready for use but still changing.**
+This means that we sometimes break backwards compatibility as we try to
+improve the software based on user experience, new ideas, better design
+decisions, etc. Please keep that in mind before you update Boule to a newer
+version.
+
+**We welcome feedback and ideas!** This is a great time to bring new ideas on
+how we can improve the project.
+[Join the conversation](https://www.fatiando.org/contact) or submit
+[issues on GitHub](https://github.com/fatiando/boule/issues).
+
 ## Getting involved
 
 🗨️ **Contact us:**
@@ -77,4 +90,4 @@ By participating in this project you agree to abide by its terms.
 
 This is free software: you can redistribute it and/or modify it under the terms
 of the **BSD 3-clause License**. A copy of this license is provided in
-`LICENSE.txt <https://github.com/fatiando/boule/blob/main/LICENSE.txt>`__.
+[`LICENSE.txt`](https://github.com/fatiando/boule/blob/main/LICENSE.txt).


### PR DESCRIPTION


<!--
Thank you for contributing a pull request! Please ensure you have taken a look 
at the CONTRIBUTING.md file in this repository (if available) and the general 
guidelines at https://github.com/fatiando/community/blob/main/CONTRIBUTING.md
-->
**Description**
<!--
Please describe changes proposed and WHY you made them.
-->

The link to the LICENSE.txt file was still using RST syntax and the
warning about project status being alpha and to expect breaking changes
was missing from the README.


**Relevant issues/PRs**
<!--
Link to relevant issues/PRs. Example: "Fixes #1234" or "See also #345"
Use keywords (e.g., Fixes, Closes) to create the links and automatically
close issues when this PR is merged. 
See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #115 