### PR TITLE
Fix formatting for code to pip install from GitHub

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -27,7 +27,7 @@ There are different ways to install Boule:
     .. tab-item:: Developement version
 
         You can use ``pip`` to install the latest **unreleased** version from
-        GitHub (**not recommended** in most situations)::
+        GitHub (**not recommended** in most situations):
 
         .. code:: bash
 


### PR DESCRIPTION

<!--
Thank you for contributing a pull request! Please ensure you have taken a look 
at the CONTRIBUTING.md file in this repository (if available) and the general 
guidelines at https://github.com/fatiando/community/blob/main/CONTRIBUTING.md
-->
**Description**
<!--
Please describe changes proposed and WHY you made them.
-->

In the install page, the pip install from GitHub code was wrong
because of a stray `::` in the paragraph above it.


**Relevant issues/PRs**
<!--
Link to relevant issues/PRs. Example: "Fixes #1234" or "See also #345"
Use keywords (e.g., Fixes, Closes) to create the links and automatically
close issues when this PR is merged. 
See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
