### PR TITLE
Make Ellipsoid.emm attribute private (i.e., _emm)

### DIFF
--- a/boule/_ellipsoid.py
+++ b/boule/_ellipsoid.py
@@ -175,8 +175,8 @@ class Ellipsoid:
         return 1 / 3 * (2 * self.semimajor_axis + self.semiminor_axis)
 
     @property
-    def emm(self):
-        r"Auxiliary quantity :math:`m = \omega^2 a^2 b / (GM)`"
+    def _emm(self):
+        "Auxiliary quantity used to calculate gravity at the pole and equator"
         return (
             self.angular_velocity**2
             * self.semimajor_axis**2
@@ -197,7 +197,9 @@ class Ellipsoid:
             / (3 * ((1 + 3 * ratio**2) * arctan - 3 * ratio))
         )
         axis_mul = self.semimajor_axis * self.semiminor_axis
-        result = self.geocentric_grav_const * (1 - self.emm - self.emm * aux) / axis_mul
+        result = (
+            self.geocentric_grav_const * (1 - self._emm - self._emm * aux) / axis_mul
+        )
         return result
 
     @property
@@ -211,7 +213,9 @@ class Ellipsoid:
             / (1.5 * ((1 + 3 * ratio**2) * arctan - 3 * ratio))
         )
         result = (
-            self.geocentric_grav_const * (1 + self.emm * aux) / self.semimajor_axis**2
+            self.geocentric_grav_const
+            * (1 + self._emm * aux)
+            / self.semimajor_axis**2
         )
         return result
 

--- a/boule/tests/test_ellipsoid.py
+++ b/boule/tests/test_ellipsoid.py
@@ -340,6 +340,11 @@ def test_normal_gravity_computed_on_internal_point(ellipsoid):
         assert len(warn) >= 1
 
 
+def test_emm_wgs84():
+    "The _emm property should be equal this value for WGS84"
+    npt.assert_allclose(WGS84._emm, 0.00344978650684)
+
+
 def test_pymap3d_integration_axis_only():
     "Check that Boule works with pymap3d functions that only need the axis"
     ellipsoid = Ellipsoid(

--- a/boule/tests/test_sphere.py
+++ b/boule/tests/test_sphere.py
@@ -115,12 +115,6 @@ def test_ellipsoidal_properties(sphere):
     npt.assert_allclose(sphere.first_eccentricity, 0)
     npt.assert_allclose(sphere.second_eccentricity, 0)
     npt.assert_allclose(sphere.mean_radius, sphere.radius)
-    npt.assert_allclose(
-        sphere.emm,
-        sphere.angular_velocity**2
-        * sphere.radius**3
-        / sphere.geocentric_grav_const,
-    )
 
 
 def test_prime_vertical_radius(sphere):

--- a/doc/ellipsoids/wgs84.rst
+++ b/doc/ellipsoids/wgs84.rst
@@ -40,8 +40,6 @@ The following are some of the derived attributes:
     8.2094437949696e-02
     >>> print("{:.4f}".format(WGS84.mean_radius))
     6371008.7714
-    >>> print("{:.14f}".format(WGS84.emm))
-    0.00344978650684
     >>> print("{:.10f}".format(WGS84.gravity_equator))
     9.7803253359
     >>> print("{:.10f}".format(WGS84.gravity_pole))


### PR DESCRIPTION


<!--
Thank you for contributing a pull request! Please ensure you have taken a look 
at the CONTRIBUTING.md file in this repository (if available) and the general 
guidelines at https://github.com/fatiando/community/blob/main/CONTRIBUTING.md
-->
**Description**
<!--
Please describe changes proposed and WHY you made them.
-->
This is only used in the calculation of gravity at the poles and
equators and has no physical meaning. It's just a convenience used
internally. So make it private to clean up the interface.

Backwards incompatible but changes of someone actually using this value are extremely low.


**Relevant issues/PRs**
<!--
Link to relevant issues/PRs. Example: "Fixes #1234" or "See also #345"
Use keywords (e.g., Fixes, Closes) to create the links and automatically
close issues when this PR is merged. 
See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
