### PR TITLE
Deprecate the coordinate conversion methods

### DIFF
--- a/boule/_ellipsoid.py
+++ b/boule/_ellipsoid.py
@@ -338,6 +338,14 @@ class Ellipsoid:
         """
         Convert from geodetic to geocentric spherical coordinates.
 
+        .. warning::
+
+            **This method is deprecated and will be removed in Boule v0.5.0.**
+            Please use the equivalent function in
+            `pymap3d <https://github.com/geospace-code/pymap3d/>`__ instead
+            (``pymap3d.geodetic2spherical``) which is available since version
+            2.9.0.
+
         The geodetic datum is defined by this ellipsoid. The coordinates are
         converted following [Vermeille2002]_.
 
@@ -363,6 +371,12 @@ class Ellipsoid:
             Converted spherical radius coordinates in meters.
 
         """
+        warn(
+            "Ellipsoid.geodetic_to_spherical is deprecated and will be removed "
+            "in Boule v0.5.0. Use pymap3d.geodetic2spherical instead.",
+            FutureWarning,
+        )
+
         latitude_rad = np.radians(latitude)
         coslat, sinlat = np.cos(latitude_rad), np.sin(latitude_rad)
         prime_vertical_radius = self.prime_vertical_radius(sinlat)
@@ -379,6 +393,14 @@ class Ellipsoid:
     def spherical_to_geodetic(self, longitude, spherical_latitude, radius):
         """
         Convert from geocentric spherical to geodetic coordinates.
+
+        .. warning::
+
+            **This method is deprecated and will be removed in Boule v0.5.0.**
+            Please use the equivalent function in
+            `pymap3d <https://github.com/geospace-code/pymap3d/>`__ instead
+            (``pymap3d.spherical2geodetic``) which is available since version
+            2.9.0.
 
         The geodetic datum is defined by this ellipsoid. The coordinates are
         converted following [Vermeille2002]_.
@@ -406,6 +428,12 @@ class Ellipsoid:
             Converted ellipsoidal height coordinates in meters.
 
         """
+        warn(
+            "Ellipsoid.spherical_to_geodetic is deprecated and will be removed "
+            "in Boule v0.5.0. Use pymap3d.spherical2geodetic instead.",
+            FutureWarning,
+        )
+
         spherical_latitude = np.radians(spherical_latitude)
         k, big_z, big_d = self._spherical_to_geodetic_terms(spherical_latitude, radius)
         latitude = np.degrees(

--- a/boule/tests/test_ellipsoid.py
+++ b/boule/tests/test_ellipsoid.py
@@ -7,8 +7,6 @@
 """
 Test the base Ellipsoid class.
 """
-import warnings
-
 import numpy as np
 import numpy.testing as npt
 import pymap3d
@@ -19,6 +17,20 @@ from .. import ELLIPSOIDS, WGS84, Ellipsoid
 from .utils import normal_gravity_surface
 
 ELLIPSOID_NAMES = [e.name for e in ELLIPSOIDS]
+
+
+def test_coordinate_conversion_deprecations():
+    """
+    Check if warn is raised when using coordinate conversion functions
+    """
+    with pytest.warns(FutureWarning) as warning:
+        WGS84.geodetic_to_spherical(0, 0, 0)
+        assert len(warning) >= 1
+        assert "geodetic2spherical" in warning[0].message.args[0]
+    with pytest.warns(FutureWarning) as warning:
+        WGS84.spherical_to_geodetic(0, 0, 6_000_000)
+        assert len(warning) >= 1
+        assert "spherical2geodetic" in warning[0].message.args[0]
 
 
 def test_check_flattening():
@@ -57,7 +69,7 @@ def test_check_flattening():
             geocentric_grav_const=0,
             angular_velocity=0,
         )
-    with warnings.catch_warnings(record=True) as warn:
+    with pytest.warns(UserWarning) as warn:
         Ellipsoid(
             name="almost-zero-flattening",
             semimajor_axis=1,
@@ -94,7 +106,7 @@ def test_check_geocentric_grav_const():
     """
     Check if warn is raised after negative geocentric_grav_const
     """
-    with warnings.catch_warnings(record=True) as warn:
+    with pytest.warns(UserWarning) as warn:
         Ellipsoid(
             name="negative_gm",
             semimajor_axis=1,
@@ -335,7 +347,7 @@ def test_normal_gravity_computed_on_internal_point(ellipsoid):
     Check if warn is raised if height is negative
     """
     latitude = np.linspace(-90, 90, 100)
-    with warnings.catch_warnings(record=True) as warn:
+    with pytest.warns(UserWarning) as warn:
         ellipsoid.normal_gravity(latitude, height=-10)
         assert len(warn) >= 1
 


### PR DESCRIPTION


<!--
Thank you for contributing a pull request! Please ensure you have taken a look 
at the CONTRIBUTING.md file in this repository (if available) and the general 
guidelines at https://github.com/fatiando/community/blob/main/CONTRIBUTING.md
-->
**Description**
<!--
Please describe changes proposed and WHY you made them.
-->

Both geocentric spherical to/from geodetic coordinate conversion methods
have been ported to pymap3d v2.9.0. Raise a FutureWarning and add a
notice to the docstrings about removal of the methods in Boule v0.5.0
and point towards the pymap3d replacements instead.


**Relevant issues/PRs**
<!--
Link to relevant issues/PRs. Example: "Fixes #1234" or "See also #345"
Use keywords (e.g., Fixes, Closes) to create the links and automatically
close issues when this PR is merged. 
See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #122 