### PR TITLE
Add serve target in doc/Makefile

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -52,3 +52,6 @@ doctest:
 	$(SPHINXBUILD) -b doctest $(ALLSPHINXOPTS) $(BUILDDIR)/doctest
 	@echo "Testing of doctests in the sources finished, look at the " \
 	      "results in $(BUILDDIR)/doctest/output.txt."
+
+serve:
+	cd $(BUILDDIR)/html && python -m http.server 8001


### PR DESCRIPTION
Add a new `serve` target in `doc/Makefile` so it's easy to serve the docs locally.
