### PR TITLE
Add co-located link glossary entry

### DIFF
--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -71,7 +71,7 @@ First, we need to import a few other packages:
     import pygmt         # For plotting maps
     import xarray as xr  # For manipulating grids
 
-Now we can download and open co-located topography and geoid grids using
+Now we can download and open :co-located:`co-located grids` topography and geoid grids using
 :mod:`ensaio` and :mod:`xarray`:
 
 .. jupyter-execute::


### PR DESCRIPTION
Substitute the occurrence of "co-located grids" with :term:`co-located grids` to automatically link to this glossary entry.
Originally @leouieda [suggestion](https://github.com/fatiando/boule/pull/139#discussion_r979169638).


<!--
Thank you for contributing a pull request to Fatiando! 💖

👆🏽 ABOVE: Describe the changes proposed and WHY you made them.

👇🏽 BELOW: Link to any relevant issue or pull request.

Please ensure you have taken a look at the CONTRIBUTING.md file 
in this repository (if available) and the general guidelines at 
https://github.com/fatiando/community/blob/main/CONTRIBUTING.md
-->


**Relevant issues/PRs:**
<!--
Example: "Fixes #1234" / "See also #345" / "Relevant to #111"
Use keywords (e.g., Fixes, Closes) to create the links and automatically
close issues when this PR is merged. 
See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Relevant to #138 and #139 