### PR TITLE
Update contact link in the docs side bar

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -157,7 +157,7 @@ Boule is designed for:
     :hidden:
     :caption: Community
 
-    Join the community <http://contact.fatiando.org>
+    Join the community <https://www.fatiando.org/contact>
     How to contribute <https://github.com/fatiando/boule/blob/main/CONTRIBUTING.md>
     Code of Conduct <https://github.com/fatiando/boule/blob/main/CODE_OF_CONDUCT.md>
     Source code on GitHub <https://github.com/fatiando/boule>


### PR DESCRIPTION
It was still pointing to the old subdomain redirect which is now invalid. Point to the main contact page on fatiando.org instead.



<!--
Thank you for contributing a pull request to Fatiando! 💖

👆🏽 ABOVE: Describe the changes proposed and WHY you made them.

👇🏽 BELOW: Link to any relevant issue or pull request.

Please ensure you have taken a look at the CONTRIBUTING.md file 
in this repository (if available) and the general guidelines at 
https://github.com/fatiando/community/blob/main/CONTRIBUTING.md
-->

**Relevant issues/PRs:**
<!--
Example: "Fixes #1234" / "See also #345" / "Relevant to #111"
Use keywords (e.g., Fixes, Closes) to create the links and automatically
close issues when this PR is merged. 
See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
