### PR TITLE
Drop support for Python 3.6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,9 +39,9 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, macos, windows]
-        python: ["3.6", "3.10"]
+        python: ["3.7", "3.10"]
         include:
-          - python: "3.6"
+          - python: "3.7"
             dependencies: oldest
           - python: "3.10"
             dependencies: latest

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -42,7 +42,7 @@ There are different ways to install Boule:
 Which Python?
 -------------
 
-You'll need **Python >= 3.6**.
+You'll need **Python >= 3.7**.
 See :ref:`python-versions` if you require support for older versions.
 
 Dependencies

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,6 @@ classifiers =
     Topic :: Scientific/Engineering
     Topic :: Software Development :: Libraries
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -38,7 +37,7 @@ project_urls =
 [options]
 zip_safe = True
 packages = find:
-python_requires = >=3.6
+python_requires = >=3.7
 install_requires =
     numpy>=1.19
     attrs>=19.3.0


### PR DESCRIPTION
We're over the deadline for dropping support according to NEP29.



<!--
Thank you for contributing a pull request to Fatiando! 💖

👆🏽 ABOVE: Describe the changes proposed and WHY you made them.

👇🏽 BELOW: Link to any relevant issue or pull request.

Please ensure you have taken a look at the CONTRIBUTING.md file 
in this repository (if available) and the general guidelines at 
https://github.com/fatiando/community/blob/main/CONTRIBUTING.md
-->

**Relevant issues/PRs:**
<!--
Example: "Fixes #1234" / "See also #345" / "Relevant to #111"
Use keywords (e.g., Fixes, Closes) to create the links and automatically
close issues when this PR is merged. 
See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #135 