### PR TITLE
Update the version of sphinx and its plugins

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -78,10 +78,10 @@ jobs:
           cat requirements-full.txt
 
       - name: Install requirements
-        run: mamba install --quiet --file requirements-full.txt python==$PYTHON
+        run: conda install --quiet --file requirements-full.txt python==$PYTHON
 
       - name: List installed packages
-        run: mamba list
+        run: conda list
 
       - name: Build source and wheel distributions
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -57,11 +57,7 @@ jobs:
         uses: conda-incubator/setup-miniconda@v3
         with:
           python-version: ${{ env.PYTHON }}
-          miniforge-variant: Mambaforge
-          use-mamba: true
           channels: conda-forge,defaults
-          # Needed for caching
-          use-only-tar-bz2: true
 
       - name: Collect requirements
         run: |
@@ -80,12 +76,6 @@ jobs:
           echo ""
           echo "Collected dependencies:"
           cat requirements-full.txt
-
-      - name: Setup caching for conda packages
-        uses: actions/cache@v4
-        with:
-          path: ~/conda_pkgs_dir
-          key: conda-${{ runner.os }}-${{ env.PYTHON }}-${{ hashFiles('requirements-full.txt') }}
 
       - name: Install requirements
         run: mamba install --quiet --file requirements-full.txt python==$PYTHON

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       REQUIREMENTS: env/requirements-docs.txt env/requirements-build.txt
-      PYTHON: "3.10"
+      PYTHON: "3.11"
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -67,7 +67,9 @@ add_function_parentheses = False
 # HTML output configuration
 # -----------------------------------------------------------------------------
 html_title = f'{project} <span class="project-version">{version}</span>'
-html_logo = "_static/boule-logo.png"
+# Don't use the logo since it gets in the way of the project name and is
+# repeated in the front page.
+# html_logo = "_static/boule-logo.png"
 html_favicon = "_static/favicon.png"
 html_last_updated_fmt = "%b %d, %Y"
 html_copy_source = True

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -21,7 +21,7 @@
 
         .. image:: ./_static/boule-logo.svg
             :width: 200px
-            :class: sd-m-auto
+            :class: sd-m-auto dark-light
 
 **Boule** is Python library for representing
 :term:`reference ellipsoids <reference ellipsoid>` geometrically, calculating

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -71,6 +71,15 @@ First, we need to import a few other packages:
     import pygmt         # For plotting maps
     import xarray as xr  # For manipulating grids
 
+.. jupyter-execute::
+   :hide-code:
+
+   # Needed so that displaying works on jupyter-sphinx and sphinx-gallery at
+   # the same time. Using PYGMT_USE_EXTERNAL_DISPLAY="false" in the Makefile
+   # for sphinx-gallery to work means that fig.show won't display anything here
+   # either.
+   pygmt.set_display(method="notebook")
+
 Now we can download and open :term:`co-located grids` of topography and geoid
 using :mod:`ensaio` and :mod:`xarray`:
 

--- a/doc/user_guide/gravity_disturbance.rst
+++ b/doc/user_guide/gravity_disturbance.rst
@@ -23,6 +23,15 @@ First off, we import the required packages to do this:
     import xarray as xr  # For loading the grid data
     import pygmt         # For plotting nice maps
 
+.. jupyter-execute::
+   :hide-code:
+
+   # Needed so that displaying works on jupyter-sphinx and sphinx-gallery at
+   # the same time. Using PYGMT_USE_EXTERNAL_DISPLAY="false" in the Makefile
+   # for sphinx-gallery to work means that fig.show won't display anything here
+   # either.
+   pygmt.set_display(method="notebook")
+
 Next, we can download and cache the gravity grid using :mod:`ensaio` and load
 it with :mod:`xarray`:
 

--- a/doc/user_guide/normal_gravity.rst
+++ b/doc/user_guide/normal_gravity.rst
@@ -58,6 +58,16 @@ Which can be put in a :class:`xarray.Dataset`:
 And plotted with :mod:`pygmt`:
 
 .. jupyter-execute::
+   :hide-code:
+
+   # Needed so that displaying works on jupyter-sphinx and sphinx-gallery at
+   # the same time. Using PYGMT_USE_EXTERNAL_DISPLAY="false" in the Makefile
+   # for sphinx-gallery to work means that fig.show won't display anything here
+   # either.
+   import pygmt
+   pygmt.set_display(method="notebook")
+
+.. jupyter-execute::
 
     import pygmt
 

--- a/env/requirements-docs.txt
+++ b/env/requirements-docs.txt
@@ -1,16 +1,16 @@
 # Requirements for building the documentation
-sphinx==4.5.*
-sphinx-book-theme==0.3.*
+sphinx==7.2.*
+sphinx-book-theme==1.1.*
 sphinx-copybutton==0.5.*
-jupyter-sphinx==0.3.*
-sphinx-design==0.1.*
+sphinx-design==0.5.*
+jupyter-sphinx==0.5.*
 ensaio
 verde
 pandas
 matplotlib
 xarray
 netcdf4
-pygmt==0.6.*
-gmt==6.3.*
+pygmt==0.11.*
+gmt==6.5.*
 ipython
 pymap3d>=2.9.0

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python==3.9
+  - python==3.11
   - pip
   - make
   # Run
@@ -18,19 +18,19 @@ dependencies:
   - coverage
   - pymap3d>=2.9
   # Documentation
-  - sphinx==4.5.*
-  - sphinx-book-theme==0.3.*
+  - sphinx==7.2.*
+  - sphinx-book-theme==1.1.*
   - sphinx-copybutton==0.5.*
-  - jupyter-sphinx==0.3.*
-  - sphinx-design==0.1.*
+  - sphinx-design==0.5.*
+  - jupyter-sphinx==0.5.*
   - ensaio
   - verde
   - pandas
   - matplotlib
   - xarray
   - netcdf4
-  - pygmt==0.6.*
-  - gmt==6.3.*
+  - pygmt==0.11.*
+  - gmt==6.5.*
   - ipython
   # Style
   - black


### PR DESCRIPTION
Use the latest version of sphinx, the docs theme, and the plugins we use. Also update GMT and PyGMT. PyGMT v0.11 in particular requires setting the display method when using jupyter-sphinx to get the figures displayed properly. This is done globally for each page using a hidden cell.
