### PR TITLE
Add mass, mean_density, and volume_equivalent_radius properties

### DIFF
--- a/boule/_constants.py
+++ b/boule/_constants.py
@@ -3,15 +3,17 @@
 # SPDX-License-Identifier: BSD-3-Clause
 #
 # This code is part of the Fatiando a Terra project (https://www.fatiando.org)
+#
 """
 Gravitational constant
 units:  m3 / (kg s2)
 
-Reference:
-E. Tiesinga, P. J. Mohr, D. B. Newell, and B. N. Taylor (2019),
-"The 2018 CODATA Recommended Values of the Fundamental Physical Constants"
-(Web Version 8.1). Database developed by J. Baker, M. Douma, and S.
-Kotochigova. Available at http://physics.nist.gov/constants, National
-Institute of Standards and Technology, Gaithersburg, MD 20899.
+Reference
+---------
+E. Tiesinga, P. J. Mohr, D. B. Newell, and B. N. Taylor (2019), The 2018
+CODATA Recommended Values of the Fundamental Physical Constants (Web Version
+8.1). Database developed by J. Baker, M. Douma, and S. Kotochigova.
+Available at http://physics.nist.gov/constants, National Institute of
+Standards and Technology, Gaithersburg, MD 20899.
 """
 G = 6.67430e-11

--- a/boule/_constants.py
+++ b/boule/_constants.py
@@ -1,0 +1,10 @@
+# Gravitational constant
+# units:  m3 / (kg s2)
+#
+# Reference:
+# E. Tiesinga, P. J. Mohr, D. B. Newell, and B. N. Taylor (2019),
+# "The 2018 CODATA Recommended Values of the Fundamental Physical Constants"
+# (Web Version 8.1). Database developed by J. Baker, M. Douma, and S.
+# Kotochigova. Available at http://physics.nist.gov/constants, National
+# Institute of Standards and Technology, Gaithersburg, MD 20899.
+G = 6.67430e-11

--- a/boule/_constants.py
+++ b/boule/_constants.py
@@ -1,10 +1,17 @@
-# Gravitational constant
-# units:  m3 / (kg s2)
+# Copyright (c) 2019 The Boule Developers.
+# Distributed under the terms of the BSD 3-Clause License.
+# SPDX-License-Identifier: BSD-3-Clause
 #
-# Reference:
-# E. Tiesinga, P. J. Mohr, D. B. Newell, and B. N. Taylor (2019),
-# "The 2018 CODATA Recommended Values of the Fundamental Physical Constants"
-# (Web Version 8.1). Database developed by J. Baker, M. Douma, and S.
-# Kotochigova. Available at http://physics.nist.gov/constants, National
-# Institute of Standards and Technology, Gaithersburg, MD 20899.
+# This code is part of the Fatiando a Terra project (https://www.fatiando.org)
+"""
+Gravitational constant
+units:  m3 / (kg s2)
+
+Reference:
+E. Tiesinga, P. J. Mohr, D. B. Newell, and B. N. Taylor (2019),
+"The 2018 CODATA Recommended Values of the Fundamental Physical Constants"
+(Web Version 8.1). Database developed by J. Baker, M. Douma, and S.
+Kotochigova. Available at http://physics.nist.gov/constants, National
+Institute of Standards and Technology, Gaithersburg, MD 20899.
+"""
 G = 6.67430e-11

--- a/boule/_ellipsoid.py
+++ b/boule/_ellipsoid.py
@@ -215,7 +215,7 @@ class Ellipsoid:
     @property
     def mean_radius(self):
         """
-        The arithmetic mean radius of the ellipsoid [Moritz1988]_.
+        The arithmetic mean radius of the ellipsoid semi-axes [Moritz1988]_.
         Definition: :math:`R_1 = (2a + b)/3`.
         Units: :math:`m`.
         """
@@ -255,7 +255,7 @@ class Ellipsoid:
         Definition: :math:`R_3 = \left(\dfrac{3}{4 \pi} V \right)^{1/3}`.
         Units: :math:`m`.
         """
-        return (self.volume * 3 / 4 / np.pi)**(1 / 3)
+        return (self.volume * 3 / 4 / np.pi) ** (1 / 3)
 
     @property
     def _emm(self):

--- a/boule/_ellipsoid.py
+++ b/boule/_ellipsoid.py
@@ -12,6 +12,8 @@ from warnings import warn
 import attr
 import numpy as np
 
+from ._constants import G
+
 
 # Don't let ellipsoid parameters be changed to avoid messing up calculations
 # accidentally.
@@ -227,6 +229,15 @@ class Ellipsoid:
         Units: :math:`m^3`.
         """
         return (4 / 3 * np.pi) * self.semimajor_axis**2 * self.semiminor_axis
+
+    @property
+    def mass(self):
+        r"""
+        The mass of the sphere.
+        Definition: :math:`M = GM / G`.
+        Units: :math:`kg`.
+        """
+        return self.geocentric_grav_const / G
 
     @property
     def _emm(self):

--- a/boule/_ellipsoid.py
+++ b/boule/_ellipsoid.py
@@ -233,11 +233,29 @@ class Ellipsoid:
     @property
     def mass(self):
         r"""
-        The mass of the sphere.
+        The mass of the ellipsoid.
         Definition: :math:`M = GM / G`.
         Units: :math:`kg`.
         """
         return self.geocentric_grav_const / G
+
+    @property
+    def mean_density(self):
+        r"""
+        The mean density of the ellipsoid.
+        Definition: :math:`\rho = M / V`.
+        Units: :math:`kg / m^3`.
+        """
+        return self.mass / self.volume
+
+    @property
+    def volume_equivalent_radius(self):
+        r"""
+        The volume equivalent radius of the ellipsoid.
+        Definition: :math:`R_3 = \left(\dfrac{3}{4 \pi} V \right)^{1/3}`.
+        Units: :math:`m`.
+        """
+        return (self.volume * 3 / 4 / np.pi)**(1 / 3)
 
     @property
     def _emm(self):

--- a/boule/_ellipsoid.py
+++ b/boule/_ellipsoid.py
@@ -103,6 +103,12 @@ class Ellipsoid:
     8.2094437949696e-02
     >>> print(f"{ellipsoid.mean_radius:.4f} m")
     6371008.7714 m
+    >>> print(f"{ellipsoid.volume_equivalent_radius:.4f} m")
+    6371000.7900 m
+    >>> print(f"{ellipsoid.mass:.10e} kg")
+    5.9721684941e+24 kg
+    >>> print(f"{ellipsoid.mean_density:.0f} kg/m³")
+    5513 kg/m³
     >>> print(f"{ellipsoid.volume * 1e-9:.5e} km³")
     1.08321e+12 km³
     >>> print(f"{ellipsoid.gravity_equator:.10f} m/s²")

--- a/boule/_sphere.py
+++ b/boule/_sphere.py
@@ -215,7 +215,6 @@ class Sphere:
     def volume_equivalent_radius(self):
         r"""
         The volume equivalent radius of the sphere is equal to its radius.
-        Added for compatibility with pymap3d.
         Definition: :math:`R_3 = R`.
         Units: :math:`m`.
         """

--- a/boule/_sphere.py
+++ b/boule/_sphere.py
@@ -181,9 +181,9 @@ class Sphere:
     @property
     def mean_radius(self):
         """
-        The mean radius of the sphere is by definition equal to its radius.
-        Added for compatibility with pymap3d.
-        Definition: :math:`R = R`.
+        The arithmetic mean radius of the ellipsoid semi-axes is equal to its
+        radius. Added for compatibility with pymap3d.
+        Definition: :math:`R_1 = R`.
         Units: :math:`m`.
         """
         return self.radius

--- a/boule/_sphere.py
+++ b/boule/_sphere.py
@@ -99,8 +99,14 @@ class Sphere:
     0
     >>> print(sphere.thirdflattening)
     0
+    >>> print(f"{sphere.volume_equivalent_radius:.1f} m")
+    1.0 m
     >>> print(f"{sphere.volume:.10f} m³")
     4.1887902048 m³
+    >>> print(f"{sphere.mass:.12e} kg")
+    2.996568928577e+10 kg
+    >>> print(f"{sphere.mean_density:.0f} kg/m³")
+    7153781359 kg/m³
 
     """
 

--- a/boule/_sphere.py
+++ b/boule/_sphere.py
@@ -179,16 +179,6 @@ class Sphere:
         return 0
 
     @property
-    def mean_radius(self):
-        """
-        The arithmetic mean radius of the ellipsoid semi-axes is equal to its
-        radius. Added for compatibility with pymap3d.
-        Definition: :math:`R_1 = R`.
-        Units: :math:`m`.
-        """
-        return self.radius
-
-    @property
     def volume(self):
         r"""
         The volume of the sphere.

--- a/boule/_sphere.py
+++ b/boule/_sphere.py
@@ -12,6 +12,8 @@ from warnings import warn
 import attr
 import numpy as np
 
+from ._constants import G
+
 
 # Don't let ellipsoid parameters be changed to avoid messing up calculations
 # accidentally.
@@ -184,6 +186,15 @@ class Sphere:
         Units: :math:`m^3`.
         """
         return (4 / 3 * np.pi) * self.radius**3
+
+    @property
+    def mass(self):
+        r"""
+        The mass of the sphere.
+        Definition: :math:`M = GM / G`.
+        Units: :math:`kg`.
+        """
+        return self.geocentric_grav_const / G
 
     def normal_gravity(self, latitude, height, si_units=False):
         r"""

--- a/boule/_sphere.py
+++ b/boule/_sphere.py
@@ -196,6 +196,25 @@ class Sphere:
         """
         return self.geocentric_grav_const / G
 
+    @property
+    def mean_density(self):
+        r"""
+        The mean density of the sphere.
+        Definition: :math:`\rho = M / V`.
+        Units: :math:`kg / m^3`.
+        """
+        return self.mass / self.volume
+
+    @property
+    def volume_equivalent_radius(self):
+        r"""
+        The volume equivalent radius of the sphere is equal to its radius.
+        Added for compatibility with pymap3d.
+        Definition: :math:`R_3 = R`.
+        Units: :math:`m`.
+        """
+        return self.radius
+
     def normal_gravity(self, latitude, height, si_units=False):
         r"""
         Normal gravity of the sphere at the given latitude and height.

--- a/boule/_sphere.py
+++ b/boule/_sphere.py
@@ -179,6 +179,16 @@ class Sphere:
         return 0
 
     @property
+    def mean_radius(self):
+        """
+        The mean radius of the sphere is by definition equal to its radius.
+        Added for compatibility with pymap3d.
+        Definition: :math:`R = R`.
+        Units: :math:`m`.
+        """
+        return self.radius
+
+    @property
     def volume(self):
         r"""
         The volume of the sphere.

--- a/boule/_triaxialellipsoid.py
+++ b/boule/_triaxialellipsoid.py
@@ -12,6 +12,8 @@ from warnings import warn
 import attr
 import numpy as np
 
+from ._constants import G
+
 
 # Don't let ellipsoid parameters be changed to avoid messing up calculations
 # accidentally.
@@ -184,6 +186,15 @@ class TriaxialEllipsoid:
             * self.semimedium_axis
             * self.semiminor_axis
         )
+
+    @property
+    def mass(self):
+        r"""
+        The mass of the ellipsoid.
+        Definition: :math:`M = GM / G`.
+        Units: :math:`kg`.
+        """
+        return self.geocentric_grav_const / G
 
     @property
     def equatorial_flattening(self):

--- a/boule/_triaxialellipsoid.py
+++ b/boule/_triaxialellipsoid.py
@@ -167,8 +167,8 @@ class TriaxialEllipsoid:
     @property
     def mean_radius(self):
         r"""
-        The arithmetic mean radius of the ellipsoid.
-        Definition: :math:`R = \dfrac{a + b + c}{3}`.
+        The arithmetic mean radius of the ellipsoid semi-axes.
+        Definition: :math:`R_1 = \dfrac{a + b + c}{3}`.
         Units: :math:`m`.
         """
         return (self.semimajor_axis + self.semimedium_axis + self.semiminor_axis) / 3
@@ -212,7 +212,7 @@ class TriaxialEllipsoid:
         Definition: :math:`R_3 = \left(\dfrac{3}{4 \pi} V \right)^{1/3}`.
         Units: :math:`m`.
         """
-        return (self.volume * 3 / 4 / np.pi)**(1 / 3)
+        return (self.volume * 3 / 4 / np.pi) ** (1 / 3)
 
     @property
     def equatorial_flattening(self):

--- a/boule/_triaxialellipsoid.py
+++ b/boule/_triaxialellipsoid.py
@@ -100,6 +100,12 @@ class TriaxialEllipsoid:
 
     >>> print(f"{ellipsoid.mean_radius:.0f} m")
     262700 m
+    >>> print(f"{ellipsoid.volume_equivalent_radius:.0f} m")
+    261115 m
+    >>> print(f"{ellipsoid.mass:.10e} kg")
+    2.5906746775e+20 kg
+    >>> print(f"{ellipsoid.mean_density:.0f} kg/m³")
+    3474 kg/m³
     >>> print(f"{ellipsoid.volume * 1e-9:.0f} km³")
     74573626 km³
 

--- a/boule/_triaxialellipsoid.py
+++ b/boule/_triaxialellipsoid.py
@@ -197,6 +197,24 @@ class TriaxialEllipsoid:
         return self.geocentric_grav_const / G
 
     @property
+    def mean_density(self):
+        r"""
+        The mean density of the ellipsoid.
+        Definition: :math:`\rho = M / V`.
+        Units: :math:`kg / m^3`.
+        """
+        return self.mass / self.volume
+
+    @property
+    def volume_equivalent_radius(self):
+        r"""
+        The volume equivalent radius of the ellipsoid.
+        Definition: :math:`R_3 = \left(\dfrac{3}{4 \pi} V \right)^{1/3}`.
+        Units: :math:`m`.
+        """
+        return (self.volume * 3 / 4 / np.pi)**(1 / 3)
+
+    @property
     def equatorial_flattening(self):
         r"""
         The equatorial flattening of the ellipsoid.


### PR DESCRIPTION
This PR addresses the issue https://github.com/fatiando/boule/issues/164 concerning the addition of `mass`, `mean_density`, and `volume_equivalent_radius` properties to the ellipsoid classes. The following changes were made:

* Created a top level file `_constants.py` to house to the gravitational constant `G` that is imported into the three ellipsoid classes.
* Added the properties `mass`, `mean_density`, and `volume_equivalent_radius` to each of the three ellipsoid classes.
* Clarified the docstrings of `mean radius`: This is, in fact, *not* the mean radius of the sphere (i.e., the degree 0 coefficient of the shape), but rather is the mean of the semi-axes (a + b + c)/3.  This is defined as R_1 in WGS84 Moritz1988.

Comments

* The mathematical equation for the `volume_equivalent_radius` is `(self.volume * 3 / 4 / np.pi)**(1 / 3)`. If we expanded the definition of `self.volume` we could probably save a couple multiplications (but at the expense of readability).
* I don't know if we need to say "Added for compatibility with pymap3d." in the `Sphere` docstrings. For me, these quantities are defined so that all classes take the same parameters.

And, I'm happy to modify anything to conform to your coding standards that are higher than mine!

**Relevant issues/PRs:**
Fixes #164

