### PR TITLE
Add true mean radius for Sphere,  Ellipsoid and TriaxialEllipsoid classes

### DIFF
--- a/boule/_ellipsoid.py
+++ b/boule/_ellipsoid.py
@@ -100,6 +100,8 @@ class Ellipsoid:
     >>> print(f"{ellipsoid.second_eccentricity:.13e}")
     8.2094437949696e-02
     >>> print(f"{ellipsoid.mean_radius:.4f} m")
+    6370994.4018 m
+    >>> print(f"{ellipsoid.semiaxes_mean_radius:.4f} m")
     6371008.7714 m
     >>> print(f"{ellipsoid.volume * 1e-9:.5e} km³")
     1.08321e+12 km³

--- a/boule/_ellipsoid.py
+++ b/boule/_ellipsoid.py
@@ -222,19 +222,24 @@ class Ellipsoid:
 
     @property
     def mean_radius(self):
-        """
+        r"""
         The mean radius of the ellipsoid. This is equivalent to the degree 0
         spherical harmonic coefficient of the ellipsoid shape.
-        Definition: :math:`R_0`.
+
+        Definition: :math:`R_0 = \dfrac{1}{4 \pi} {\displaystyle \int_0^{\pi}
+        \int_0^{2 \pi}} r(\theta) \sin \theta \, d\theta \, d\lambda`
+
+        in which :math:`r` is the ellipsoid spherical radius, :math:`\theta` is
+        spherical latitude, and :math:`\lambda` is spherical longitude.
+
         Units: :math:`m`.
         """
         # The mean radius is obtained by integration in spherical coordinates.
-        # The integral over longitude is computed analytically, and the
-        # integral over geocentric latitude is performed using Gauss-Legendre
-        # quadrature. Tests show that n = 30 will return the mean radius
-        # to machine precision for an object with a flattening of 0.5 (which
-        # is 100 times larger than that of Mars). In an abundance of caution,
-        # we chose to use n = 50.
+        # The integral over longitude is 2 pi, and the integral over spherical
+        # latitude is performed using Gauss-Legendre quadrature. Tests show
+        # that n = 30 will return the mean radius to machine precision for an
+        # object with a flattening of 0.5 (which is 100 times larger than that
+        # of Mars). In an abundance of caution, we chose to use n = 50.
         n = 50
         x, weights = np.polynomial.legendre.leggauss(n)
         geocentric_latitude = 90.0 - np.rad2deg(np.arccos(x))

--- a/boule/_ellipsoid.py
+++ b/boule/_ellipsoid.py
@@ -213,7 +213,28 @@ class Ellipsoid:
     @property
     def mean_radius(self):
         """
-        The arithmetic mean radius of the ellipsoid [Moritz1988]_.
+        The mean radius of the ellipsoid. This is equivalent to the degree 0
+        spherical harmonic coefficient of the ellipsoid shape.
+        Definition: :math:`R_0`.
+        Units: :math:`m`.
+        """
+        # The mean radius is obtained by integration in spherical coordinates.
+        # The integral over longitude is computed analytically, and the
+        # integral over geocentric latitude is performed using Gauss-Legendre
+        # quadrature. Experiments show that n = 30 will return the mean radius
+        # to machine precision for an object with the semimajor axis of Mars
+        # and a flattening of 0.5 (which is 100 times larger than that of
+        # Mars). In an abundance of caution, we chose to use n = 50.
+        n = 50
+        x, weights = np.polynomial.legendre.leggauss(n)
+        geocentric_latitude = 90.0 - np.rad2deg(np.arccos(x))
+        radius = self.geocentric_radius(geocentric_latitude, geodetic=False)
+        return np.sum(radius * weights) / 2
+
+    @property
+    def semiaxes_mean_radius(self):
+        """
+        The arithmetic mean radius of the ellipsoid semi-axes [Moritz1988]_.
         Definition: :math:`R_1 = (2a + b)/3`.
         Units: :math:`m`.
         """

--- a/boule/_sphere.py
+++ b/boule/_sphere.py
@@ -177,6 +177,26 @@ class Sphere:
         return 0
 
     @property
+    def mean_radius(self):
+        """
+        The mean radius of the ellipsoid is equal to its radius. Added for
+        compatibility with pymap3d.
+        Definition: :math:`R_0 = R`.
+        Units: :math:`m`.
+        """
+        return self.radius
+
+    @property
+    def semiaxes_mean_radius(self):
+        """
+        The arithmetic mean radius of the ellipsoid semi-axes is equal to its
+        radius. Added for compatibility with pymap3d.
+        Definition: :math:`R_1 = R`.
+        Units: :math:`m`.
+        """
+        return self.radius
+
+    @property
     def volume(self):
         r"""
         The volume of the sphere.

--- a/boule/_sphere.py
+++ b/boule/_sphere.py
@@ -97,6 +97,10 @@ class Sphere:
     0
     >>> print(sphere.thirdflattening)
     0
+    >>> print(sphere.mean_radius)
+    1
+    >>> print(sphere.semiaxes_mean_radius)
+    1
     >>> print(f"{sphere.volume:.10f} m³")
     4.1887902048 m³
 

--- a/boule/_triaxialellipsoid.py
+++ b/boule/_triaxialellipsoid.py
@@ -174,17 +174,23 @@ class TriaxialEllipsoid:
 
     @property
     def mean_radius(self):
-        """
+        r"""
         The mean radius of the ellipsoid. This is equivalent to the degree 0
         spherical harmonic coefficient of the ellipsoid shape.
-        Definition: :math:`R_0`.
+
+        Definition: :math:`R_0 = \dfrac{1}{4 \pi} {\displaystyle \int_0^{\pi}
+        \int_0^{2 \pi}} r(\theta, \lambda) \sin \theta \, d\theta \, d\lambda`
+
+        in which :math:`r` is the ellipsoid spherical radius, :math:`\theta` is
+        spherical latitude, and :math:`\lambda` is spherical longitude.
+
         Units: :math:`m`.
         """
         # The mean radius is obtained by integration in spherical coordinates.
         # Gauss-Legendre quadrature is used to perform the integration over
-        # both geocentric longitude and geocentric latitude. Experiments show
-        # that n = 16 will return the mean radius to machine precision for
-        # the asteroid (4) Vesta, and that machine precision results for a
+        # both spherical longitude and spherical latitude. Tests show that
+        # n = 16 will return the mean radius to machine precision for the
+        # asteroid (4) Vesta, and that machine precision results for a
         # Vesta-like object with half the semiminor axis as Vesta are obtained
         # for n = 38. In an abundance of caution, we chose to use n = 50.
         n = 50
@@ -205,7 +211,7 @@ class TriaxialEllipsoid:
         # Multiply the radius by the weights, and then sum the result
         radius *= weights_latitude[:, np.newaxis]
         radius *= weights_longitude[np.newaxis, :]
-        return np.sum(radius) / 4 / np.pi
+        return np.sum(radius) / (4 * np.pi)
 
     @property
     def semiaxes_mean_radius(self):

--- a/boule/_triaxialellipsoid.py
+++ b/boule/_triaxialellipsoid.py
@@ -164,9 +164,44 @@ class TriaxialEllipsoid:
 
     @property
     def mean_radius(self):
+        """
+        The mean radius of the ellipsoid. This is equivalent to the degree 0
+        spherical harmonic coefficient of the ellipsoid shape.
+        Definition: :math:`R_0`.
+        Units: :math:`m`.
+        """
+        # The mean radius is obtained by integration in spherical coordinates.
+        # Gauss-Legendre quadrature is used to perform the integration over
+        # both geocentric longitude and geocentric latitude. Experiments show
+        # that n = 16 will return the mean radius to machine precision for
+        # the asteroid (4) Vesta, and that machine precision results for a
+        # Vesta-like object with half the semiminor axis as Vesta are obtained
+        # for n = 38. In an abundance of caution, we chose to use n = 50.
+        n = 50
+        x_latitude, weights_latitude = np.polynomial.legendre.leggauss(n)
+        x_longitude, weights_longitude = np.polynomial.legendre.leggauss(2 * n)
+
+        geocentric_latitude = 90.0 - np.rad2deg(np.arccos(x_latitude))
+        # Rescale longitude integration limits from [-1, 1] to [0, 2 pi]
+        # https://en.wikipedia.org/wiki/Gaussian_quadrature#Change_of_interval
+        weights_longitude *= np.pi
+        geocentric_longitude = np.rad2deg(np.pi * x_longitude + np.pi)
+
+        lats, lons = np.meshgrid(
+            geocentric_latitude, geocentric_longitude, indexing="ij"
+        )
+        radius = self.geocentric_radius(lons, lats)
+
+        # Multiply the radius by the weights, and then sum the result
+        radius *= weights_latitude[:, np.newaxis]
+        radius *= weights_longitude[np.newaxis, :]
+        return np.sum(radius) / 4 / np.pi
+
+    @property
+    def semiaxes_mean_radius(self):
         r"""
-        The arithmetic mean radius of the ellipsoid.
-        Definition: :math:`R = \dfrac{a + b + c}{3}`.
+        The arithmetic mean radius of the ellipsoid semi-axes.
+        Definition: :math:`R_1 = \dfrac{a + b + c}{3}`.
         Units: :math:`m`.
         """
         return (self.semimajor_axis + self.semimedium_axis + self.semiminor_axis) / 3

--- a/boule/_triaxialellipsoid.py
+++ b/boule/_triaxialellipsoid.py
@@ -97,6 +97,8 @@ class TriaxialEllipsoid:
     parameters:
 
     >>> print(f"{ellipsoid.mean_radius:.0f} m")
+    259813 m
+    >>> print(f"{ellipsoid.semiaxes_mean_radius:.0f} m")
     262700 m
     >>> print(f"{ellipsoid.volume * 1e-9:.0f} km³")
     74573626 km³


### PR DESCRIPTION
This PR adds a property that computes the "true" mean radius of the ellipsoid as described in #174. The following changes were made:

1. The old Sphere/Ellipsoid/TriaxialEllipsoid `mean_radius` properties were renamed to `semiaxes_mean_radius` ($R_1$).
2. A new property `mean_radius` ($R_0$) was added that computes the mean radius using Gauss Legendre quadrature. The quadrature routine is taken directly from numpy, and requires no additional imports.

**Note:**
There is a single parameter that needs to be defined, which is the number of quadrature points to use. (For triaxial ellipsoids, I set the number of points in longitude to be twice that in latitude). For the ellipsoids that are already defined in boule, tests show that about n=10 is sufficient to get machine precision results. Tests for extreme ellipsoids with a flattening of 0.5 (which is 100 times greater than for Mars) requires n=30. Tests for a Vesta-like object where the semimajor axis is reduced by a factor of two requires n=38. In an extreme abundance of caution, I have chosen to use n=50, which is probably sufficient for any solar system object. I have cross checked these results using the degree-0 spherical harmonic coefficients calculated with the independent code pyshtools, which compare to the last digit (or two).

**Relevant issues/PRs:**
resolves #174 
