### PR TITLE
New ellipsoids

### DIFF
--- a/boule/__init__.py
+++ b/boule/__init__.py
@@ -16,6 +16,8 @@ from ._realizations import (
     Moon2015,
     Venus2015,
     Vesta2012,
+    Vesta2017_biaxial,
+    Vesta2017_triaxial,
 )
 from ._sphere import Sphere
 from ._triaxialellipsoid import TriaxialEllipsoid

--- a/boule/__init__.py
+++ b/boule/__init__.py
@@ -11,6 +11,7 @@ from ._realizations import (
     GRS80,
     WGS84,
     Ceres2018,
+    Io2024,
     Mars2009,
     Mercury2015,
     Mercury2024,

--- a/boule/__init__.py
+++ b/boule/__init__.py
@@ -6,7 +6,16 @@
 #
 # Import functions/classes to make the public API
 from ._ellipsoid import Ellipsoid
-from ._realizations import Mercury2015, GRS80, MARS, MOON, VENUS, VESTA, WGS84
+from ._realizations import (
+    GRS80,
+    MARS,
+    MOON,
+    VENUS,
+    VESTA,
+    WGS84,
+    Mercury2015,
+    Mercury2024,
+)
 from ._sphere import Sphere
 from ._triaxialellipsoid import TriaxialEllipsoid
 from ._version import __version__

--- a/boule/__init__.py
+++ b/boule/__init__.py
@@ -12,6 +12,7 @@ from ._realizations import (
     WGS84,
     Callisto2024,
     Ceres2018,
+    Enceladus2024,
     Europa2024,
     Ganymede2024,
     Io2024,

--- a/boule/__init__.py
+++ b/boule/__init__.py
@@ -12,6 +12,7 @@ from ._realizations import (
     WGS84,
     Callisto2024,
     Ceres2018,
+    Charon2024,
     Enceladus2024,
     Europa2024,
     Ganymede2024,

--- a/boule/__init__.py
+++ b/boule/__init__.py
@@ -9,13 +9,13 @@ from ._ellipsoid import Ellipsoid
 from ._realizations import (
     EGM96,
     GRS80,
-    Mars2009,
-    VESTA,
     WGS84,
+    Mars2009,
     Mercury2015,
     Mercury2024,
     Moon2015,
     Venus2015,
+    Vesta2012,
 )
 from ._sphere import Sphere
 from ._triaxialellipsoid import TriaxialEllipsoid

--- a/boule/__init__.py
+++ b/boule/__init__.py
@@ -6,7 +6,7 @@
 #
 # Import functions/classes to make the public API
 from ._ellipsoid import Ellipsoid
-from ._realizations import GRS80, MARS, MERCURY, MOON, VENUS, VESTA, WGS84
+from ._realizations import Mercury2015, GRS80, MARS, MOON, VENUS, VESTA, WGS84
 from ._sphere import Sphere
 from ._triaxialellipsoid import TriaxialEllipsoid
 from ._version import __version__

--- a/boule/__init__.py
+++ b/boule/__init__.py
@@ -20,6 +20,7 @@ from ._realizations import (
     Mercury2015,
     Mercury2024,
     Moon2015,
+    Titan2024,
     Venus2015,
     Vesta2017,
     Vesta2017_triaxial,

--- a/boule/__init__.py
+++ b/boule/__init__.py
@@ -10,11 +10,11 @@ from ._realizations import (
     EGM96,
     GRS80,
     MARS,
-    MOON,
     VESTA,
     WGS84,
     Mercury2015,
     Mercury2024,
+    Moon2015,
     Venus2015,
 )
 from ._sphere import Sphere

--- a/boule/__init__.py
+++ b/boule/__init__.py
@@ -9,7 +9,7 @@ from ._ellipsoid import Ellipsoid
 from ._realizations import (
     EGM96,
     GRS80,
-    MARS,
+    Mars2009,
     VESTA,
     WGS84,
     Mercury2015,

--- a/boule/__init__.py
+++ b/boule/__init__.py
@@ -10,6 +10,7 @@ from ._realizations import (
     EGM96,
     GRS80,
     WGS84,
+    Callisto2024,
     Ceres2018,
     Europa2024,
     Ganymede2024,

--- a/boule/__init__.py
+++ b/boule/__init__.py
@@ -10,11 +10,11 @@ from ._realizations import (
     GRS80,
     MARS,
     MOON,
-    VENUS,
     VESTA,
     WGS84,
     Mercury2015,
     Mercury2024,
+    Venus2015,
 )
 from ._sphere import Sphere
 from ._triaxialellipsoid import TriaxialEllipsoid

--- a/boule/__init__.py
+++ b/boule/__init__.py
@@ -10,13 +10,14 @@ from ._realizations import (
     EGM96,
     GRS80,
     WGS84,
+    Ceres2018,
     Mars2009,
     Mercury2015,
     Mercury2024,
     Moon2015,
     Venus2015,
-    Vesta2012,
-    Vesta2017_biaxial,
+    Vesta2012_triaxial,
+    Vesta2017,
     Vesta2017_triaxial,
 )
 from ._sphere import Sphere

--- a/boule/__init__.py
+++ b/boule/__init__.py
@@ -20,6 +20,7 @@ from ._realizations import (
     Mercury2015,
     Mercury2024,
     Moon2015,
+    Pluto2024,
     Titan2024,
     Venus2015,
     Vesta2017,

--- a/boule/__init__.py
+++ b/boule/__init__.py
@@ -12,6 +12,7 @@ from ._realizations import (
     WGS84,
     Ceres2018,
     Europa2024,
+    Ganymede2024,
     Io2024,
     Mars2009,
     Mercury2015,

--- a/boule/__init__.py
+++ b/boule/__init__.py
@@ -16,7 +16,6 @@ from ._realizations import (
     Mercury2024,
     Moon2015,
     Venus2015,
-    Vesta2012_triaxial,
     Vesta2017,
     Vesta2017_triaxial,
 )

--- a/boule/__init__.py
+++ b/boule/__init__.py
@@ -7,6 +7,7 @@
 # Import functions/classes to make the public API
 from ._ellipsoid import Ellipsoid
 from ._realizations import (
+    EGM96,
     GRS80,
     MARS,
     MOON,

--- a/boule/__init__.py
+++ b/boule/__init__.py
@@ -11,6 +11,7 @@ from ._realizations import (
     GRS80,
     WGS84,
     Ceres2018,
+    Europa2024,
     Io2024,
     Mars2009,
     Mercury2015,

--- a/boule/_realizations.py
+++ b/boule/_realizations.py
@@ -315,3 +315,19 @@ Pluto2024 = Sphere(
         "https://doi.org/10.1016/j.icarus.2014.03.015; "
     ),
 )
+
+Charon2024 = Sphere(
+    name="Charon2024",
+    long_name="Charon spheroid (2024)",
+    radius=606_000,
+    geocentric_grav_const=105.88e9,
+    angular_velocity=1.1385591834674098e-055,
+    reference=(
+        "R: Nimmo, et al. (2017). Mean radius and shape of Pluto and Charon "
+        "from New Horizons images. Icarus, 287, 12–29. "
+        "https://doi.org/10.1016/j.icarus.2016.06.027; "
+        "GM, OMEGA: Brozović, M., et al. (2015). The orbits and masses of "
+        "satellites of Pluto. Icarus, 246, 317–329. "
+        "https://doi.org/10.1016/j.icarus.2014.03.015; "
+    ),
+)

--- a/boule/_realizations.py
+++ b/boule/_realizations.py
@@ -171,3 +171,21 @@ Vesta2017_triaxial = TriaxialEllipsoid(
         "71–82. https://doi.org/10.1016/j.epsl.2017.07.033"
     ),
 )
+
+Ceres2018 = Ellipsoid(
+    name="Ceres2018",
+    long_name="Ceres ellipsoid (2018)",
+    semimajor_axis=482_100,
+    flattening=(482_100 - 445.94) / 482_100,
+    geocentric_grav_const=62629053612.1,
+    angular_velocity=1.9234038694078873e-4,
+    reference=(
+        "A, F: Park, R. S., et al. (2019). High-resolution shape model of "
+        "Ceres from stereophotoclinometry using Dawn Imaging Data. Icarus, "
+        "319, 812–827. https://doi.org/10.1016/j.icarus.2018.10.024; "
+        "GM, OMEGA: Konopliv, A. S., et al. (2018). The Ceres gravity field, "
+        "spin pole, rotation period and orbit from the Dawn radiometric "
+        "tracking and optical data. Icarus, 299, 411–429. "
+        "https://doi.org/10.1016/j.icarus.2017.08.005"
+    ),
+)

--- a/boule/_realizations.py
+++ b/boule/_realizations.py
@@ -40,6 +40,19 @@ Mercury2024 = Sphere(
     ),
 )
 
+Venus2015 = Sphere(
+    name="Venus2015",
+    long_name="Venus Spheroid (2015)",
+    radius=6_051_878,
+    geocentric_grav_const=324.858592e12,
+    angular_velocity=-299.24e-9,
+    reference=(
+        "Wieczorek, MA (2015). 10.05 - Gravity and Topography of the Terrestrial "
+        "Planets, Treatise of Geophysics (Second Edition); Elsevier. "
+        "doi:10.1016/B978-0-444-53802-4.00169-X"
+    ),
+)
+
 WGS84 = Ellipsoid(
     name="WGS84",
     long_name="World Geodetic System 1984",
@@ -80,19 +93,6 @@ MARS = Ellipsoid(
         "Equipotential Surface, and Reference Ellipsoid for the Planet Mars. "
         "Earth, Moon, and Planets, 106(1), 1. "
         "doi:10.1007/s11038-009-9342-7"
-    ),
-)
-
-VENUS = Sphere(
-    name="VENUS",
-    long_name="Venus Spheroid",
-    radius=6_051_878,
-    geocentric_grav_const=324.858592e12,
-    angular_velocity=-299.24e-9,
-    reference=(
-        "Wieczorek, MA (2015). 10.05 - Gravity and Topography of the Terrestrial "
-        "Planets, Treatise of Geophysics (Second Edition); Elsevier. "
-        "doi:10.1016/B978-0-444-53802-4.00169-X"
     ),
 )
 

--- a/boule/_realizations.py
+++ b/boule/_realizations.py
@@ -299,3 +299,19 @@ Titan2024 = Sphere(
         "https://doi.org/10.3847/1538-3881/ac90c9"
     ),
 )
+
+Pluto2024 = Sphere(
+    name="Pluto2024",
+    long_name="Pluto spheroid (2024)",
+    radius=1_188_300,
+    geocentric_grav_const=869.6e9,
+    angular_velocity=1.1385591834674098e-05,
+    reference=(
+        "R: Nimmo, et al. (2017). Mean radius and shape of Pluto and Charon "
+        "from New Horizons images. Icarus, 287, 12–29. "
+        "https://doi.org/10.1016/j.icarus.2016.06.027; "
+        "GM, OMEGA: Brozović, M., et al. (2015). The orbits and masses of "
+        "satellites of Pluto. Icarus, 246, 317–329. "
+        "https://doi.org/10.1016/j.icarus.2014.03.015; "
+    ),
+)

--- a/boule/_realizations.py
+++ b/boule/_realizations.py
@@ -24,6 +24,22 @@ Mercury2015 = Sphere(
     ),
 )
 
+Mercury2024 = Sphere(
+    name="Mercury2024",
+    long_name="Mercury Spheroid (2023)",
+    radius=2439472.7,
+    geocentric_grav_const=22031815411154.895,
+    angular_velocity=1.2400141739494342e-06,
+    reference=(
+        "R: Maia, J. (2024). Spherical harmonic models of the shape of "
+        "Mercury [Data set]. Zenodo. https://doi.org/10.5281/zenodo.10809345; "
+        "GM, OMEGA: Mazarico, E., et al. (2014), The gravity field, "
+        "orientation, and ephemeris of Mercury from MESSENGER observations "
+        "after three years in orbit, J. Geophys. Res. Planets, 119, "
+        "2417-2436, doi:10.1002/2014JE004675."
+    ),
+)
+
 WGS84 = Ellipsoid(
     name="WGS84",
     long_name="World Geodetic System 1984",

--- a/boule/_realizations.py
+++ b/boule/_realizations.py
@@ -188,10 +188,34 @@ Io2024 = TriaxialEllipsoid(
     reference=(
         "A, B, C: Thomas, P. C., et al. (1998). The Shape of Io from Galileo "
         "Limb Measurements. Icarus, 135(1), 175–180. "
-        "https://doi.org/10.1006/icar.1998.5987"
+        "https://doi.org/10.1006/icar.1998.5987; "
         "GM: Anderson, J. D., et al. (2001). Io's gravity field and interior "
         "structure. J. Geophys. Res., 106, 32963–32969. "
-        "https://doi.org/10.1029/2000JE001367"
+        "https://doi.org/10.1029/2000JE001367; "
+        "OMEGA: R. A. Jacobson (2021), The Orbits of the Regular Jovian "
+        "Satellites and the Orientation of the Pole of Jupiter, personal "
+        "communication to Horizons/NAIF. Accessed via JPL Solar System "
+        "Dynamics, https://ssd.jpl.nasa.gov, JUP365."
+    ),
+)
+
+Europa2024 = TriaxialEllipsoid(
+    # Nominal hydrostatic ellipsoid
+    name="Europa2024",
+    long_name="Europa hydrostatic ellipsoid (2024)",
+    semimajor_axis=1_562_600,
+    semimedium_axis=1_560_100,
+    semiminor_axis=1_559_300,
+    geocentric_grav_const=3202.72e9,
+    angular_velocity=2 * _np.pi / (3.525463 * 24 * 60 * 60),
+    reference=(
+        "A, B, C: Nimmo, F., et al. (2007). The global shape of Europa: "
+        "Constraints on lateral shell thickness variations. Icarus, 191(1), "
+        "183–192. https://doi.org/10.1016/j.icarus.2007.04.021"
+        "https://doi.org/10.1006/icar.1998.5987; "
+        "GM: Anderson, J. D., et al. (1998). Europa's differentiated internal "
+        "structure: Inferences from four Galileo encounters. Science, 281, "
+        "2019–2022. https://doi.org/10.1126/science.281.5385.2019; "
         "OMEGA: R. A. Jacobson (2021), The Orbits of the Regular Jovian "
         "Satellites and the Orientation of the Pole of Jupiter, personal "
         "communication to Horizons/NAIF. Accessed via JPL Solar System "

--- a/boule/_realizations.py
+++ b/boule/_realizations.py
@@ -179,7 +179,7 @@ Io2024 = TriaxialEllipsoid(
     # Best-fit equilibrium shape of Thomas et al. 1998. Their best fit
     # ellipsoid shape differs by less than 300 m for each axis.
     name="Io2024",
-    long_name="Io equilibrium ellipsoid (2024)",
+    long_name="Io equilibrium triaxial ellipsoid (2024)",
     semimajor_axis=1_829_700,
     semimedium_axis=1_819_200,
     semiminor_axis=1_815_800,
@@ -202,7 +202,7 @@ Io2024 = TriaxialEllipsoid(
 Europa2024 = TriaxialEllipsoid(
     # Nominal hydrostatic ellipsoid
     name="Europa2024",
-    long_name="Europa hydrostatic ellipsoid (2024)",
+    long_name="Europa equilibrium triaxial ellipsoid (2024)",
     semimajor_axis=1_562_600,
     semimedium_axis=1_560_100,
     semiminor_axis=1_559_300,
@@ -226,7 +226,7 @@ Europa2024 = TriaxialEllipsoid(
 Ganymede2024 = TriaxialEllipsoid(
     # Equilibrium ellipsoid III
     name="Ganymede2024",
-    long_name="Ganymede equilibrium ellipsoid (2024)",
+    long_name="Ganymede equilibrium triaxial ellipsoid (2024)",
     semimajor_axis=2_634_770,
     semimedium_axis=2_632_380,
     semiminor_axis=2_631_590,
@@ -259,5 +259,20 @@ Callisto2024 = Sphere(
         "OMEGA: Satellites and the Orientation of the Pole of Jupiter, "
         "personal communication to Horizons/NAIF. Accessed via JPL Solar "
         "System Dynamics, https://ssd.jpl.nasa.gov, JUP365."
+    ),
+)
+
+Enceladus2024 = TriaxialEllipsoid(
+    name="Enceladus2024",
+    long_name="Enceladus triaxial ellipsoid (2024)",
+    semimajor_axis=256_140,
+    semimedium_axis=251_160,
+    semiminor_axis=248_680,
+    geocentric_grav_const=7.210443e9,
+    angular_velocity=262.7318870466 * 2.0 * np.pi / 360.0 / (24.0 * 60.0 * 60.0),
+    reference=(
+        "Park, R. S., et al. (2024). The Global Shape, Gravity Field, and "
+        "Libration of Enceladus. Journal of Geophysical Research: Planets, "
+        "129(1), e2023JE008054. https://doi.org/10.1029/2023JE008054"
     ),
 )

--- a/boule/_realizations.py
+++ b/boule/_realizations.py
@@ -80,6 +80,19 @@ GRS80 = Ellipsoid(
     ),
 )
 
+EGM96 = Ellipsoid(
+    name="EGM96",
+    long_name="Earth Gravitational Model 1996",
+    semimajor_axis=6378136.3,
+    flattening=1 / 0.298256415099e3,
+    geocentric_grav_const=3986004.415e8,
+    angular_velocity=7292115e-11,
+    reference=(
+        "Lemoine, F. G., et al. (1998). The Development of the Joint NASA "
+        "GSFC and the National Imagery and Mapping Agency (NIMA) Geopotential "
+        "Model EGM96. NASA Goddard Space Flight Center, NASA/TP 1998-206861."
+    ),
+)
 
 MARS = Ellipsoid(
     name="MARS",

--- a/boule/_realizations.py
+++ b/boule/_realizations.py
@@ -207,7 +207,7 @@ Europa2024 = TriaxialEllipsoid(
     semimedium_axis=1_560_100,
     semiminor_axis=1_559_300,
     geocentric_grav_const=3202.72e9,
-    angular_velocity=2 * _np.pi / (3.525463 * 24 * 60 * 60),
+    angular_velocity=2 * np.pi / (3.525463 * 24 * 60 * 60),
     reference=(
         "A, B, C: Nimmo, F., et al. (2007). The global shape of Europa: "
         "Constraints on lateral shell thickness variations. Icarus, 191(1), "
@@ -216,6 +216,29 @@ Europa2024 = TriaxialEllipsoid(
         "GM: Anderson, J. D., et al. (1998). Europa's differentiated internal "
         "structure: Inferences from four Galileo encounters. Science, 281, "
         "2019–2022. https://doi.org/10.1126/science.281.5385.2019; "
+        "OMEGA: R. A. Jacobson (2021), The Orbits of the Regular Jovian "
+        "Satellites and the Orientation of the Pole of Jupiter, personal "
+        "communication to Horizons/NAIF. Accessed via JPL Solar System "
+        "Dynamics, https://ssd.jpl.nasa.gov, JUP365."
+    ),
+)
+
+Ganymede2024 = TriaxialEllipsoid(
+    # Equilibrium ellipsoid III
+    name="Ganymede2024",
+    long_name="Ganymede equilibrium ellipsoid (2024)",
+    semimajor_axis=2_634_770,
+    semimedium_axis=2_632_380,
+    semiminor_axis=2_631_590,
+    geocentric_grav_const=9.8878041807018262e12,
+    angular_velocity=2 * np.pi / (7.155588 * 24 * 60 * 60),
+    reference=(
+        "A, B, C: Zubarev, A., et al. (2015). New Ganymede control point "
+        "network and global shape model. Planetary and Space Science, 117, "
+        "246–249. https://doi.org/10.1016/j.pss.2015.06.022; "
+        "GM: Gomez Casajus, L., et al. (2022). Gravity Field of Ganymede After "
+        "the Juno Extended Mission. Geophysical Research Letters, 49(24), "
+        "e2022GL099475, doi:10.1029/2022GL099475.; "
         "OMEGA: R. A. Jacobson (2021), The Orbits of the Regular Jovian "
         "Satellites and the Orientation of the Pole of Jupiter, personal "
         "communication to Horizons/NAIF. Accessed via JPL Solar System "

--- a/boule/_realizations.py
+++ b/boule/_realizations.py
@@ -122,14 +122,14 @@ Mars2009 = Ellipsoid(
     ),
 )
 
-VESTA = TriaxialEllipsoid(
-    name="VESTA",
-    long_name="Vesta Triaxial Ellipsoid",
+Vesta2012 = TriaxialEllipsoid(
+    name="Vesta2012",
+    long_name="Vesta Triaxial Ellipsoid (2012)",
     semimajor_axis=286_300,
     semimedium_axis=278_600,
     semiminor_axis=223_200,
-    geocentric_grav_const=1.729094e10,
-    angular_velocity=326.71050958367e-6,
+    geocentric_grav_const=2.59076e20 * 6.6743e-11,
+    angular_velocity=1617.333119 * 2 * np.pi / 360 / 24 / 60 / 60,
     reference=(
         "Russell, C. T., Raymond, C. A., Coradini, A., McSween, H. Y., Zuber, "
         "M. T., Nathues, A., et al. (2012). Dawn at Vesta: Testing the "

--- a/boule/_realizations.py
+++ b/boule/_realizations.py
@@ -245,3 +245,19 @@ Ganymede2024 = TriaxialEllipsoid(
         "Dynamics, https://ssd.jpl.nasa.gov, JUP365."
     ),
 )
+
+Callisto2024 = Sphere(
+    name="Callisto2024",
+    long_name="Callisto spheroid (2024)",
+    radius=2_410_300,
+    geocentric_grav_const=7179.292e9,
+    angular_velocity=2 * np.pi / (16.690440 * 24 * 60 * 60),
+    reference=(
+        "R, GM: Anderson, J. D., et al. (2001). Shape, mean radius, gravity "
+        "field, and interior structure of Callisto. Icarus, 153(1), 157–161. "
+        "https://doi.org/10.1006/icar.2001.6664; "
+        "OMEGA: Satellites and the Orientation of the Pole of Jupiter, "
+        "personal communication to Horizons/NAIF. Accessed via JPL Solar "
+        "System Dynamics, https://ssd.jpl.nasa.gov, JUP365."
+    ),
+)

--- a/boule/_realizations.py
+++ b/boule/_realizations.py
@@ -11,6 +11,19 @@ from ._ellipsoid import Ellipsoid
 from ._sphere import Sphere
 from ._triaxialellipsoid import TriaxialEllipsoid
 
+Mercury2015 = Sphere(
+    name="Mercury2015",
+    long_name="Mercury Spheroid (2015)",
+    radius=2_439_372,
+    geocentric_grav_const=22.031839224e12,
+    angular_velocity=1.2400172589e-6,
+    reference=(
+        "Wieczorek, MA (2015). 10.05 - Gravity and Topography of the Terrestrial "
+        "Planets, Treatise of Geophysics (Second Edition); Elsevier. "
+        "doi:10.1016/B978-0-444-53802-4.00169-X"
+    ),
+)
+
 WGS84 = Ellipsoid(
     name="WGS84",
     long_name="World Geodetic System 1984",
@@ -73,19 +86,6 @@ MOON = Sphere(
     radius=1_737_151,
     geocentric_grav_const=4.90280007e12,
     angular_velocity=2.6617073e-6,
-    reference=(
-        "Wieczorek, MA (2015). 10.05 - Gravity and Topography of the Terrestrial "
-        "Planets, Treatise of Geophysics (Second Edition); Elsevier. "
-        "doi:10.1016/B978-0-444-53802-4.00169-X"
-    ),
-)
-
-MERCURY = Sphere(
-    name="MERCURY",
-    long_name="Mercury Spheroid",
-    radius=2_439_372,
-    geocentric_grav_const=22.031839221e12,
-    angular_velocity=1.2400172589e-6,
     reference=(
         "Wieczorek, MA (2015). 10.05 - Gravity and Topography of the Terrestrial "
         "Planets, Treatise of Geophysics (Second Edition); Elsevier. "

--- a/boule/_realizations.py
+++ b/boule/_realizations.py
@@ -174,3 +174,27 @@ Ceres2018 = Ellipsoid(
         "https://doi.org/10.1016/j.icarus.2017.08.005"
     ),
 )
+
+Io2024 = TriaxialEllipsoid(
+    # Best-fit equilibrium shape of Thomas et al. 1998. Their best fit
+    # ellipsoid shape differs by less than 300 m for each axis.
+    name="Io2024",
+    long_name="Io equilibrium ellipsoid (2024)",
+    semimajor_axis=1_829_700,
+    semimedium_axis=1_819_200,
+    semiminor_axis=1_815_800,
+    geocentric_grav_const=5959.91e9,
+    angular_velocity=2 * np.pi / (1.762732 * 24 * 60 * 60),
+    reference=(
+        "A, B, C: Thomas, P. C., et al. (1998). The Shape of Io from Galileo "
+        "Limb Measurements. Icarus, 135(1), 175–180. "
+        "https://doi.org/10.1006/icar.1998.5987"
+        "GM: Anderson, J. D., et al. (2001). Io's gravity field and interior "
+        "structure. J. Geophys. Res., 106, 32963–32969. "
+        "https://doi.org/10.1029/2000JE001367"
+        "OMEGA: R. A. Jacobson (2021), The Orbits of the Regular Jovian "
+        "Satellites and the Orientation of the Pole of Jupiter, personal "
+        "communication to Horizons/NAIF. Accessed via JPL Solar System "
+        "Dynamics, https://ssd.jpl.nasa.gov, JUP365."
+    ),
+)

--- a/boule/_realizations.py
+++ b/boule/_realizations.py
@@ -107,9 +107,9 @@ Moon2015 = Sphere(
     ),
 )
 
-MARS = Ellipsoid(
-    name="MARS",
-    long_name="Mars Ellipsoid",
+Mars2009 = Ellipsoid(
+    name="Mars2009",
+    long_name="Mars Ellipsoid (2009)",
     semimajor_axis=3_395_428,
     flattening=(3_395_428 - 3_377_678) / 3_395_428,
     geocentric_grav_const=42828.372e9,

--- a/boule/_realizations.py
+++ b/boule/_realizations.py
@@ -7,13 +7,15 @@
 """
 Ellipsoid and Sphere realizations for the Earth and other planetary bodies.
 """
+import numpy as np
+
 from ._ellipsoid import Ellipsoid
 from ._sphere import Sphere
 from ._triaxialellipsoid import TriaxialEllipsoid
 
 Mercury2015 = Sphere(
     name="Mercury2015",
-    long_name="Mercury Spheroid (2015)",
+    long_name="Mercury spheroid (2015)",
     radius=2_439_372,
     geocentric_grav_const=22.031839224e12,
     angular_velocity=1.2400172589e-6,
@@ -26,7 +28,7 @@ Mercury2015 = Sphere(
 
 Mercury2024 = Sphere(
     name="Mercury2024",
-    long_name="Mercury Spheroid (2023)",
+    long_name="Mercury spheroid (2023)",
     radius=2439472.7,
     geocentric_grav_const=22031815411154.895,
     angular_velocity=1.2400141739494342e-06,
@@ -42,7 +44,7 @@ Mercury2024 = Sphere(
 
 Venus2015 = Sphere(
     name="Venus2015",
-    long_name="Venus Spheroid (2015)",
+    long_name="Venus spheroid (2015)",
     radius=6_051_878,
     geocentric_grav_const=324.858592e12,
     angular_velocity=-299.24e-9,
@@ -55,7 +57,7 @@ Venus2015 = Sphere(
 
 WGS84 = Ellipsoid(
     name="WGS84",
-    long_name="World Geodetic System 1984",
+    long_name="World Geodetic System (1984)",
     semimajor_axis=6378137,
     flattening=1 / 298.257223563,
     geocentric_grav_const=3986004.418e8,
@@ -69,7 +71,7 @@ WGS84 = Ellipsoid(
 
 GRS80 = Ellipsoid(
     name="GRS80",
-    long_name="Geodetic Reference System 1980",
+    long_name="Geodetic Reference System (1980)",
     semimajor_axis=6378137,
     flattening=1 / 298.257222101,
     geocentric_grav_const=3986005.0e8,
@@ -82,7 +84,7 @@ GRS80 = Ellipsoid(
 
 EGM96 = Ellipsoid(
     name="EGM96",
-    long_name="Earth Gravitational Model 1996",
+    long_name="Earth Gravitational Model (1996)",
     semimajor_axis=6378136.3,
     flattening=1 / 0.298256415099e3,
     geocentric_grav_const=3986004.415e8,
@@ -96,7 +98,7 @@ EGM96 = Ellipsoid(
 
 Moon2015 = Sphere(
     name="Moon2015",
-    long_name="Moon Spheroid (2015)",
+    long_name="Moon spheroid (2015)",
     radius=1_737_151,
     geocentric_grav_const=4.90280007e12,
     angular_velocity=2.6617073e-6,
@@ -109,7 +111,7 @@ Moon2015 = Sphere(
 
 Mars2009 = Ellipsoid(
     name="Mars2009",
-    long_name="Mars Ellipsoid (2009)",
+    long_name="Mars ellipsoid (2009)",
     semimajor_axis=3_395_428,
     flattening=(3_395_428 - 3_377_678) / 3_395_428,
     geocentric_grav_const=42828.372e9,
@@ -122,9 +124,9 @@ Mars2009 = Ellipsoid(
     ),
 )
 
-Vesta2012 = TriaxialEllipsoid(
-    name="Vesta2012",
-    long_name="Vesta Triaxial Ellipsoid (2012)",
+Vesta2012_triaxial = TriaxialEllipsoid(
+    name="Vesta2012_triaxial",
+    long_name="Vesta triaxial ellipsoid (2012)",
     semimajor_axis=286_300,
     semimedium_axis=278_600,
     semiminor_axis=223_200,
@@ -134,5 +136,38 @@ Vesta2012 = TriaxialEllipsoid(
         "Russell, C. T., Raymond, C. A., Coradini, A., McSween, H. Y., Zuber, "
         "M. T., Nathues, A., et al. (2012). Dawn at Vesta: Testing the "
         "Protoplanetary Paradigm. Science. doi:10.1126/science.1219381"
+    ),
+)
+
+Vesta2017 = Ellipsoid(
+    name="Vesta2017",
+    long_name="Vesta reference ellipsoid (2017)",
+    semimajor_axis=278_556,
+    flattening=(278_556 - 229_921) / 278_556,
+    geocentric_grav_const=17.288e9,
+    angular_velocity=3.267e-4,
+    reference=(
+        "Karimi, R., Azmoudeh Ardalan, A., & Vasheghani Farahani, S. (2017). "
+        "The size, shape and orientation of the asteroid Vesta based on data "
+        "from the Dawn mission. Earth and Planetary Science Letters, 475, "
+        "71–82. https://doi.org/10.1016/j.epsl.2017.07.033"
+    ),
+)
+
+Vesta2017_triaxial = TriaxialEllipsoid(
+    # Note that this triaxial reference ellipsoid is rotated in longitude
+    # by 8.29 E with respect to the Vesta coordinate system.
+    name="Vesta2017_triaxial",
+    long_name="Vesta triaxial reference ellipsoid (2017)",
+    semimajor_axis=280_413,
+    semimedium_axis=274_572,
+    semiminor_axis=231_253,
+    geocentric_grav_const=17.288e9,
+    angular_velocity=3.267e-4,
+    reference=(
+        "Karimi, R., Azmoudeh Ardalan, A., & Vasheghani Farahani, S. (2017). "
+        "The size, shape and orientation of the asteroid Vesta based on data "
+        "from the Dawn mission. Earth and Planetary Science Letters, 475, "
+        "71–82. https://doi.org/10.1016/j.epsl.2017.07.033"
     ),
 )

--- a/boule/_realizations.py
+++ b/boule/_realizations.py
@@ -276,3 +276,26 @@ Enceladus2024 = TriaxialEllipsoid(
         "129(1), e2023JE008054. https://doi.org/10.1029/2023JE008054"
     ),
 )
+
+Titan2024 = Sphere(
+    # Ellispoid fit to data (not from spherical harmonic coefficients)
+    name="Titan2024",
+    long_name="Titan triaxial ellipsoid (2024)",
+    semimajor_axis=2_575_164,
+    semimedium_axis=2_574_720,
+    semiminor_axis=2_574_314,
+    geocentric_grav_const=8978.1383e9,
+    angular_velocity=2 * np.pi / (15.945448 * 24 * 60 * 60),
+    reference=(
+        "A, B, C: Corlies, P., et al. (2017). Titan’s Topography and Shape at "
+        "the End of the Cassini Mission. Geophysical Research Letters, 44(23), "
+        "11,754-11,761. https://doi.org/10.1002/2017GL075518; "
+        "GM: Durante, D., et al. (2019). Titan’s gravity field and interior "
+        "structure after Cassini. Icarus, 326, 123–132. "
+        "https://doi.org/10.1016/j.icarus.2019.03.003; "
+        "OMEGA: Jacobson, R. (2022). The Orbits of the Main Saturnian "
+        "Satellites, the Saturnian System Gravity Field, and the Orientation "
+        "of Saturn's Pole. The Astronomical Journal, 164, 199. "
+        "https://doi.org/10.3847/1538-3881/ac90c9"
+    ),
+)

--- a/boule/_realizations.py
+++ b/boule/_realizations.py
@@ -94,6 +94,19 @@ EGM96 = Ellipsoid(
     ),
 )
 
+Moon2015 = Sphere(
+    name="Moon2015",
+    long_name="Moon Spheroid (2015)",
+    radius=1_737_151,
+    geocentric_grav_const=4.90280007e12,
+    angular_velocity=2.6617073e-6,
+    reference=(
+        "Wieczorek, MA (2015). 10.05 - Gravity and Topography of the Terrestrial "
+        "Planets, Treatise of Geophysics (Second Edition); Elsevier. "
+        "doi:10.1016/B978-0-444-53802-4.00169-X"
+    ),
+)
+
 MARS = Ellipsoid(
     name="MARS",
     long_name="Mars Ellipsoid",
@@ -106,19 +119,6 @@ MARS = Ellipsoid(
         "Equipotential Surface, and Reference Ellipsoid for the Planet Mars. "
         "Earth, Moon, and Planets, 106(1), 1. "
         "doi:10.1007/s11038-009-9342-7"
-    ),
-)
-
-MOON = Sphere(
-    name="MOON",
-    long_name="Moon Spheroid",
-    radius=1_737_151,
-    geocentric_grav_const=4.90280007e12,
-    angular_velocity=2.6617073e-6,
-    reference=(
-        "Wieczorek, MA (2015). 10.05 - Gravity and Topography of the Terrestrial "
-        "Planets, Treatise of Geophysics (Second Edition); Elsevier. "
-        "doi:10.1016/B978-0-444-53802-4.00169-X"
     ),
 )
 

--- a/boule/_realizations.py
+++ b/boule/_realizations.py
@@ -124,21 +124,6 @@ Mars2009 = Ellipsoid(
     ),
 )
 
-Vesta2012_triaxial = TriaxialEllipsoid(
-    name="Vesta2012_triaxial",
-    long_name="Vesta triaxial ellipsoid (2012)",
-    semimajor_axis=286_300,
-    semimedium_axis=278_600,
-    semiminor_axis=223_200,
-    geocentric_grav_const=2.59076e20 * 6.6743e-11,
-    angular_velocity=1617.333119 * 2 * np.pi / 360 / 24 / 60 / 60,
-    reference=(
-        "Russell, C. T., Raymond, C. A., Coradini, A., McSween, H. Y., Zuber, "
-        "M. T., Nathues, A., et al. (2012). Dawn at Vesta: Testing the "
-        "Protoplanetary Paradigm. Science. doi:10.1126/science.1219381"
-    ),
-)
-
 Vesta2017 = Ellipsoid(
     name="Vesta2017",
     long_name="Vesta reference ellipsoid (2017)",

--- a/boule/tests/test_ellipsoid.py
+++ b/boule/tests/test_ellipsoid.py
@@ -13,10 +13,10 @@ import numpy as np
 import numpy.testing as npt
 import pytest
 
-from .. import GRS80, MARS, WGS84, Ellipsoid
+from .. import GRS80, WGS84, Ellipsoid, Mars2009
 from .utils import normal_gravity_surface
 
-ELLIPSOIDS = [WGS84, GRS80, MARS]
+ELLIPSOIDS = [WGS84, GRS80, Mars2009]
 ELLIPSOID_NAMES = [e.name for e in ELLIPSOIDS]
 
 

--- a/boule/tests/test_pymap3d.py
+++ b/boule/tests/test_pymap3d.py
@@ -13,17 +13,17 @@ import pymap3d
 import pymap3d.latitude
 import pytest
 
-from .. import MOON, VENUS, WGS84, Ellipsoid
+from .. import WGS84, Ellipsoid, Moon2015, Venus2015
 
 
 @pytest.mark.parametrize(
     "ellipsoid,coordinates",
     [
         (WGS84, (42.014671, -82.006479, 276.9)),
-        (MOON, (41.823366, -82.006479, 4631727)),
-        (VENUS, (41.823366, -82.006479, 317000)),
+        (Moon2015, (41.823366, -82.006479, 4631727)),
+        (Venus2015, (41.823366, -82.006479, 317000)),
     ],
-    ids=["WGS84", "Moon", "Venus"],
+    ids=["WGS84", "Moon2015", "Venus2015"],
 )
 def test_pymap3d_integration_different_ellipsoids(ellipsoid, coordinates):
     "Check that Boule Ellipsoids and Spheres work with pymap3d functions"


### PR DESCRIPTION
The PR contains a large number of new ellipsoids, renames a few preexisting ellipoids, and removes the prexisting Vesta ellipsoid.

Here is the list of all the implemented ellipsoids with some notes:

## Mercury
* Mercury2015 (previously MERCURY, updated the last digit of GM that was incorrect)
* Mercury2024 (new, updated R and GM)

## Venus
* Venus2015 (previously VENUS)

## Earth
* GRS80
* WGS84
* EGM96 (new)

## Moon
* Moon2015 (previously MOON)

## Asteroids
* Ceres2018 (new)
* Vesta2017 (new)
* Vesta2017_triaxial (new)
* VESTA Removed (see comments below)

## Mars
* Mars2009 (previously MARS)

## Jupiter system
* Io2024 (new)
* Europa2024 (new)
* Ganymede2024 (new)
* Callisto2024 (new)

## Saturn system
* Enceladus2024 (new)
* Titan2024 (new)

## Pluto system
* Pluto2024 (new)
* Charon2024 (new)

# Notes
I removed the original VESTA triaxial ellipsoid because there is not enough information in the paper to determine the GM, it is not stated if the ellipsoid is geocentric or offset from the center of mass, and the directions of the principal axes are not given. I think that keeping this ellipsoid as is will just cause problems for people who use it. I wasted a lot of time trying to figure this one out... Instead, two new ellipsoids have been added: The default (Vesta2017) is biaxial, as Vesta has no real tides. The Vesta2017_triaxial ellispoid, in contrast, is triaxial. The triaxial one, however, is **not** aligned with the topography and gravity coordinate axes: I think that we will probably need to add additional attributes to the TriaxialEllipsoid class for the unit vectors of the semi-axes.

Note that I have simply imported all the ellipsoids into the main namespace. I suspect that this will be too messy for people. As I mentioned in the related issue, we could instead put all of the ellipsoid realizations into a new submodule called `ellipsoids`.

In many cases, papers generated several ellipsoids, and I noted which one I chose as an inline comment. I think that these comments should be placed in an optional "comments" attribute of each class. In general, I chose to use ellipsoids that were geocentric (with their center corresponding to the center of mass), and also chose to use the "hydrostatic" constrained ellipsoids for the satellites of Jupiter.

Lastly, note that the ellipsoid year corresponds to the year when all the required data were published, or to the year that we assembled the ellipsoid ourselves using various sources.

**Relevant issues/PRs:**
Relevant to #176 