### PR TITLE
Add centrifugal potential to Ellipsoid and Sphere

### DIFF
--- a/boule/_ellipsoid.py
+++ b/boule/_ellipsoid.py
@@ -619,3 +619,47 @@ class Ellipsoid:
             gamma *= 1e5
 
         return gamma
+
+    def centrifugal_potential(self, latitude, height):
+        r"""
+        Centrifugal potential at the given geodetic latitude and height above
+        the ellipsoid.
+
+        Parameters
+        ----------
+        latitude : float or array
+            The geodetic latitude where the centrifugal potential will be
+            computed (in degrees).
+        height : float or array
+            The ellipsoidal (geometric) height of the computation point (in
+            meters).
+
+        Returns
+        -------
+        Phi : float or array
+            The centrifugal potential in m²/s².
+
+        Notes
+        -----
+
+        The centrifugal potential :math:`\Phi` at geodetic latitude
+        :math:`\phi` and height above the ellipsoid :math:`h` (geometric
+        height) is
+
+        .. math::
+
+            \Phi(\phi, h) = \dfrac{1}{2}
+                \omega^2 \left(N(\phi) + h\right)^2 \cos^2(\phi)
+
+        in which :math:`N(\phi)` is the prime vertical radius of curvature of
+        the ellipsoid.
+        """
+        # Pre-compute to avoid repeated calculations
+        sinlat = np.sin(np.radians(latitude))
+        coslat = np.sqrt(1 - sinlat**2)
+
+        return (1 / 2) * (
+            self.angular_velocity
+            * (self.prime_vertical_radius(sinlat) + height)
+            * coslat
+        ) ** 2

--- a/boule/_sphere.py
+++ b/boule/_sphere.py
@@ -379,3 +379,39 @@ class Sphere:
             gamma *= 1e5
 
         return gamma
+
+    def centrifugal_potential(self, latitude, height):
+        r"""
+        Centrifugal potential at the given latitude and height.
+
+        Parameters
+        ----------
+        latitude : float or array
+            The latitude where the centrifugal potential will be computed
+            (in degrees).
+        height : float or array
+            The height above the sphere of the computation point (in meters).
+
+        Returns
+        -------
+        Phi : float or array
+            The centrifugal potential in m²/s².
+
+        Notes
+        -----
+
+        The centrifugal potential :math:`\Phi` at latitude :math:`\phi` and
+        height above the sphere :math:`h` is
+
+        .. math::
+
+            \Phi(\phi, h) = \dfrac{1}{2}
+                \omega^2 \left(R + h\right)^2 \cos^2(\phi)
+
+        in which :math:`R` is the sphere radius.
+        """
+        return (1 / 2) * (
+            self.angular_velocity
+            * (self.radius + height)
+            * np.cos(np.radians(latitude))
+        ) ** 2


### PR DESCRIPTION
This PR allows one to compute the centrifugal potential of a rotating Sphere of Ellipsoid. The equations are simple. For the Ellipsoid class, I used the definition of the prime radius of curvature to compute the perpendicular distance to the rotation axis: $(N(\phi) + h) \cos\phi$, where $\phi$ is geodetic latitude and $h$ is ellipsoidal height. 

A separate PR will implement this for triaxial ellipsoids, as we will need to change how we handle `longitude_semimajor_axis`.

**Relevant issues/PRs:**
Relevant to #151 