### PR TITLE
Turn longitude_semimajor_axis into an optional attribute

### DIFF
--- a/boule/_triaxialellipsoid.py
+++ b/boule/_triaxialellipsoid.py
@@ -22,8 +22,10 @@ class TriaxialEllipsoid:
 
     The ellipsoid is defined by five parameters: semimajor axis, semimedium
     axis, semiminor axis, geocentric gravitational constant, and angular
-    velocity The thee semi-axis are different and the ellipsoid spins around
-    it's largest moment of inertia.
+    velocity. The ellipsoid spins around it's smallest semiminor axis, which
+    is aligned with the Cartesian z coordinate axis. The semimajor and
+    semimedium axes are in the x-y plane, and if not specified otherwise,
+    coincide with the Cartesian x and y axes.
 
     **This class is read-only:** Input parameters and attributes cannot be
     changed after instantiation.
@@ -32,7 +34,7 @@ class TriaxialEllipsoid:
 
     .. attention::
 
-        Gravity calculations have not been implemented yet for triaxial
+        Most gravity calculations have not been implemented yet for triaxial
         ellipsoids. If you're interested in this feature or would like to help
         implement it, please
         `get in touch <https://www.fatiando.org/contact>`__.
@@ -62,6 +64,9 @@ class TriaxialEllipsoid:
         The angular velocity of the rotating ellipsoid.
         Definition: :math:`\omega`.
         Units: :math:`\\rad.s^{-1}`.
+    semimajor_axis_longitude : float
+        Longitude coordinate of the semimajor axis in the x-y plane. Optional,
+        default value is 0.0.
     long_name : str or None
         A long name for the ellipsoid, for example ``"World Geodetic System
         1984"`` (optional).
@@ -109,6 +114,7 @@ class TriaxialEllipsoid:
     semiminor_axis = attr.ib()
     geocentric_grav_const = attr.ib()
     angular_velocity = attr.ib()
+    semimajor_axis_longitude = attr.ib(default=0.0)
     long_name = attr.ib(default=None)
     reference = attr.ib(default=None)
 
@@ -204,7 +210,7 @@ class TriaxialEllipsoid:
         """
         return (self.semimajor_axis - self.semiminor_axis) / self.semimajor_axis
 
-    def geocentric_radius(self, longitude, latitude, longitude_semimajor_axis=0.0):
+    def geocentric_radius(self, longitude, latitude):
         r"""
         Radial distance from the center of the ellipsoid to its surface.
 
@@ -217,10 +223,6 @@ class TriaxialEllipsoid:
             Longitude coordinates on spherical coordinate system in degrees.
         latitude : float or array
             Latitude coordinates on spherical coordinate system in degrees.
-        longitude_semimajor_axis : float (optional)
-            Longitude coordinate of the meridian containing the semi-major axis
-            on spherical coordinate system in degrees. Optional, default value
-            is 0.0.
 
         Returns
         -------
@@ -278,7 +280,7 @@ class TriaxialEllipsoid:
         """
         latitude_rad = np.radians(latitude)
         longitude_rad = np.radians(longitude)
-        longitude_semimajor_axis_rad = np.radians(longitude_semimajor_axis)
+        longitude_semimajor_axis_rad = np.radians(self.semimajor_axis_longitude)
 
         coslat, sinlat = np.cos(latitude_rad), np.sin(latitude_rad)
 

--- a/boule/_triaxialellipsoid.py
+++ b/boule/_triaxialellipsoid.py
@@ -22,10 +22,11 @@ class TriaxialEllipsoid:
 
     The ellipsoid is defined by five parameters: semimajor axis, semimedium
     axis, semiminor axis, geocentric gravitational constant, and angular
-    velocity. The ellipsoid spins around it's smallest semiminor axis, which
+    velocity. The ellipsoid spins around its smallest (semiminor) axis, which
     is aligned with the Cartesian z coordinate axis. The semimajor and
-    semimedium axes are in the x-y plane, and if not specified otherwise,
-    coincide with the Cartesian x and y axes.
+    semimedium axes are in the x-y plane, and by default coincide with the
+    Cartesian x and y coordinate axes. Optionally, the ellipsoid can be rotated
+    about the z axis by specifying the longitude of the semimajor axis.
 
     **This class is read-only:** Input parameters and attributes cannot be
     changed after instantiation.

--- a/boule/tests/test_triaxialellipsoid.py
+++ b/boule/tests/test_triaxialellipsoid.py
@@ -30,6 +30,21 @@ def triaxialellipsoid():
     return triaxial_ellipsoid
 
 
+@pytest.fixture
+def triaxialellipsoid_90():
+    "A triaxial ellipsoid rotated 90 degress about the z axis"
+    triaxial_ellipsoid = TriaxialEllipsoid(
+        name="Base triaxial Ellipsoid",
+        semimajor_axis=4,
+        semimedium_axis=2,
+        semiminor_axis=1,
+        geocentric_grav_const=2.0,
+        angular_velocity=1.3,
+        semimajor_axis_longitude=90.0,
+    )
+    return triaxial_ellipsoid
+
+
 def test_check_semimajor():
     """
     Check if error is raised after invalid semimajor axis
@@ -233,7 +248,7 @@ def test_geocentric_radius_equator(triaxialellipsoid):
     )
 
 
-def test_geocentric_radius_semimajor_axis_longitude(triaxialellipsoid):
+def test_geocentric_radius_semimajor_axis_longitude(triaxialellipsoid_90):
     """
     Check against non-zero longitude of the semi-major axis
     """
@@ -241,14 +256,14 @@ def test_geocentric_radius_semimajor_axis_longitude(triaxialellipsoid):
     longitude = np.array([0.0, 90.0, 180.0, 270.0])
     radius_true = np.array(
         [
-            triaxialellipsoid.semimedium_axis,
-            triaxialellipsoid.semimajor_axis,
-            triaxialellipsoid.semimedium_axis,
-            triaxialellipsoid.semimajor_axis,
+            triaxialellipsoid_90.semimedium_axis,
+            triaxialellipsoid_90.semimajor_axis,
+            triaxialellipsoid_90.semimedium_axis,
+            triaxialellipsoid_90.semimajor_axis,
         ]
     )
     npt.assert_allclose(
-        radius_true, triaxialellipsoid.geocentric_radius(longitude, latitude, 90.0)
+        radius_true, triaxialellipsoid_90.geocentric_radius(longitude, latitude)
     )
 
 


### PR DESCRIPTION
This PR turns `longitude_semimajor_axis` (renamed to `semimajor_axis_longitude`) into an optional attribute that is used to instantiate triaxial ellipsoids.

Previously, this parameter was found as an optional argument to the `geocentric radius` function. However, this parameter is an intrinsic property of the ellipsoid, and will be necessary for all routines that make use of longitude coordinates. As this is now declared as a class attribute, I have thus remove this optional parameter from `geocentric radius`.

The `test_geocentric_radius_semimajor_axis_longitude` was somewhat modified: I declared a new ellipsoid `triaxialellipsoid_90` that set `semimajor_axis_longitude` to 90.

As soon as this PR is merged, I will add the `centrifugal_potential` method (which requires the updated `geocentric_radius` function).

Note that at some point, we may want to allow for ellipsoids that are not rotating about the z axis, but this is probably far off into the future.

**Relevant issues/PRs:**
