### PR TITLE
Add comments attribute to all ellipsoid classes

### DIFF
--- a/boule/_ellipsoid.py
+++ b/boule/_ellipsoid.py
@@ -22,7 +22,7 @@ class Ellipsoid:
 
     The ellipsoid is defined by four parameters: semimajor axis, flattening,
     geocentric gravitational constant, and angular velocity. It spins around
-    it's semiminor axis and has constant gravity potential at its surface. The
+    its semiminor axis and has constant gravity potential at its surface. The
     internal density structure of the ellipsoid is unspecified but must be such
     that the constant potential condition is satisfied.
 
@@ -57,6 +57,8 @@ class Ellipsoid:
         1984"`` (optional).
     reference : str or None
         Citation for the ellipsoid parameter values (optional).
+    comments : str or None
+        Additional comments regarding the ellipsoid (optional).
 
 
     .. caution::
@@ -119,6 +121,7 @@ class Ellipsoid:
     angular_velocity = attr.ib()
     long_name = attr.ib(default=None)
     reference = attr.ib(default=None)
+    comments = attr.ib(default=None)
 
     @flattening.validator
     def _check_flattening(self, flattening, value):

--- a/boule/_sphere.py
+++ b/boule/_sphere.py
@@ -54,6 +54,8 @@ class Sphere:
         (optional).
     reference : str or None
         Citation for the sphere parameter values (optional).
+    comments : str or None
+        Additional comments regarding the ellipsoid (optional).
 
 
     .. caution::
@@ -108,6 +110,7 @@ class Sphere:
     angular_velocity = attr.ib()
     long_name = attr.ib(default=None)
     reference = attr.ib(default=None)
+    comments = attr.ib(default=None)
 
     @radius.validator
     def _check_radius(self, radius, value):

--- a/boule/_triaxialellipsoid.py
+++ b/boule/_triaxialellipsoid.py
@@ -67,6 +67,8 @@ class TriaxialEllipsoid:
         1984"`` (optional).
     reference : str or None
         Citation for the ellipsoid parameter values (optional).
+    comments : str or None
+        Additional comments regarding the ellipsoid (optional).
 
     Examples
     --------
@@ -111,6 +113,7 @@ class TriaxialEllipsoid:
     angular_velocity = attr.ib()
     long_name = attr.ib(default=None)
     reference = attr.ib(default=None)
+    comments = attr.ib(default=None)
 
     def _raise_invalid_axis(self):
         "Raise a ValueError informing that the axis are invalid."


### PR DESCRIPTION
This PR adds an attribute `comments` that is used when instantiating the ellipsoid classes. The default value is None. This attribute can provide additional information for understanding the origin of the numbers used to instantiate the class, or on how to/no-to use the class (such as, for example "tide free").

**Relevant issues/PRs:**
Fixes #179