### PR TITLE
Drop support for Python 3.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,9 +38,9 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, macos, windows]
-        python: ["3.7", "3.11"]
+        python: ["3.8", "3.11"]
         include:
-          - python: "3.7"
+          - python: "3.8"
             dependencies: oldest
           - python: "3.11"
             dependencies: latest

--- a/doc/compatibility.rst
+++ b/doc/compatibility.rst
@@ -62,3 +62,5 @@ following releases to ensure compatibility:
       - **Last compatible release**
     * - 3.6
       - 0.4.0
+    * - 3.7
+      - 0.4.1

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -42,7 +42,7 @@ There are different ways to install Boule:
 Which Python?
 -------------
 
-You'll need **Python >= 3.7**.
+You'll need **Python >= 3.8**.
 See :ref:`python-versions` if you require support for older versions.
 
 Dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,13 +22,12 @@ classifiers = [
     "Topic :: Software Development :: Libraries",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 dependencies = [
     "numpy>=1.19",
     "attrs>=19.3.0",


### PR DESCRIPTION
It's long overdue and we no longer need to support it. Upgrade the project setting, CI matrix, and version compatibility docs.

