### PR TITLE
Add `semimedium_axis` property to sphere and ellipsoid

### DIFF
--- a/boule/_ellipsoid.py
+++ b/boule/_ellipsoid.py
@@ -183,6 +183,15 @@ class Ellipsoid:
         return self.semimajor_axis * (1 - self.flattening)
 
     @property
+    def semimedium_axis(self):
+        """
+        The semimedium axis of the ellipsoid is equal to its semimajor axis.
+        Definition: :math:`b = a`.
+        Units: :math:`m`.
+        """
+        return self.semimajor_axis
+
+    @property
     def thirdflattening(self):
         r"""
         The third flattening of the ellipsoid (used in geodetic calculations).

--- a/boule/_ellipsoid.py
+++ b/boule/_ellipsoid.py
@@ -186,7 +186,6 @@ class Ellipsoid:
     def semimedium_axis(self):
         """
         The semimedium axis of the ellipsoid is equal to its semimajor axis.
-        Definition: :math:`b = a`.
         Units: :math:`m`.
         """
         return self.semimajor_axis

--- a/boule/_ellipsoid.py
+++ b/boule/_ellipsoid.py
@@ -192,7 +192,7 @@ class Ellipsoid:
         return self.semimajor_axis
 
     @property
-    def semimajor_axis_longitide(self):
+    def semimajor_axis_longitude(self):
         r"""
         The semimajor axis longitude of the ellipsoid is equal to zero.
         Definition: :math:`\lambda_a = 0`.

--- a/boule/_ellipsoid.py
+++ b/boule/_ellipsoid.py
@@ -192,6 +192,15 @@ class Ellipsoid:
         return self.semimajor_axis
 
     @property
+    def semimajor_axis_longitide(self):
+        r"""
+        The semimajor axis longitude of the ellipsoid is equal to zero.
+        Definition: :math:`\lambda_a = 0`.
+        Units: :math:`m`.
+        """
+        return 0
+
+    @property
     def thirdflattening(self):
         r"""
         The third flattening of the ellipsoid (used in geodetic calculations).

--- a/boule/_sphere.py
+++ b/boule/_sphere.py
@@ -153,6 +153,16 @@ class Sphere:
         return self.radius
 
     @property
+    def semimedium_axis(self):
+        """
+        The semimedium axis of the sphere is equal to its radius. Added for
+        compatibility with pymap3d.
+        Definition: :math:`a = R`.
+        Units: :math:`m`.
+        """
+        return self.radius
+
+    @property
     def semimajor_axis(self):
         """
         The semimajor axis of the sphere is equal to its radius. Added for

--- a/boule/_sphere.py
+++ b/boule/_sphere.py
@@ -170,7 +170,7 @@ class Sphere:
         return self.radius
 
     @property
-    def semimajor_axis_longitide(self):
+    def semimajor_axis_longitude(self):
         r"""
         The semimajor axis longitude of the sphere is equal to zero.
         Definition: :math:`\lambda_a = 0`.

--- a/boule/_sphere.py
+++ b/boule/_sphere.py
@@ -145,8 +145,7 @@ class Sphere:
     @property
     def semiminor_axis(self):
         """
-        The semiminor axis of the sphere is equal to its radius. Added for
-        compatibility with pymap3d.
+        The semiminor axis of the sphere is equal to its radius.
         Definition: :math:`b = R`.
         Units: :math:`m`.
         """
@@ -155,8 +154,7 @@ class Sphere:
     @property
     def semimedium_axis(self):
         """
-        The semimedium axis of the sphere is equal to its radius. Added for
-        compatibility with pymap3d.
+        The semimedium axis of the sphere is equal to its radius.
         Definition: :math:`a = R`.
         Units: :math:`m`.
         """
@@ -165,18 +163,25 @@ class Sphere:
     @property
     def semimajor_axis(self):
         """
-        The semimajor axis of the sphere is equal to its radius. Added for
-        compatibility with pymap3d.
+        The semimajor axis of the sphere is equal to its radius.
         Definition: :math:`a = R`.
         Units: :math:`m`.
         """
         return self.radius
 
     @property
+    def semimajor_axis_longitide(self):
+        r"""
+        The semimajor axis longitude of the sphere is equal to zero.
+        Definition: :math:`\lambda_a = 0`.
+        Units: :math:`m`.
+        """
+        return 0
+
+    @property
     def flattening(self):
         r"""
-        The flattening of the sphere is equal to zero. Added for compatibility
-        with pymap3d.
+        The flattening of the sphere is equal to zero.
         Definition: :math:`f = \dfrac{a - b}{a}`.
         Units: adimensional.
         """
@@ -185,8 +190,7 @@ class Sphere:
     @property
     def thirdflattening(self):
         r"""
-        The third flattening of the sphere is equal to zero. Added for
-        compatibility with pymap3d
+        The third flattening of the sphere is equal to zero.
         Definition: :math:`f^{\prime\prime}= \dfrac{a -b}{a + b}`.
         Units: adimensional.
         """
@@ -200,8 +204,7 @@ class Sphere:
     @property
     def first_eccentricity(self):
         r"""
-        The (first) eccentricity of the sphere is equal to zero. Added for
-        compatibility with pymap3d.
+        The (first) eccentricity of the sphere is equal to zero.
         Definition: :math:`e = \dfrac{\sqrt{a^2 - b^2}}{a} = \sqrt{2f - f^2}`.
         Units: adimensional.
         """
@@ -219,8 +222,7 @@ class Sphere:
     @property
     def mean_radius(self):
         """
-        The mean radius of the ellipsoid is equal to its radius. Added for
-        compatibility with pymap3d.
+        The mean radius of the ellipsoid is equal to its radius.
         Definition: :math:`R_0 = R`.
         Units: :math:`m`.
         """
@@ -230,7 +232,7 @@ class Sphere:
     def semiaxes_mean_radius(self):
         """
         The arithmetic mean radius of the ellipsoid semi-axes is equal to its
-        radius. Added for compatibility with pymap3d.
+        radius.
         Definition: :math:`R_1 = R`.
         Units: :math:`m`.
         """

--- a/boule/_sphere.py
+++ b/boule/_sphere.py
@@ -146,7 +146,6 @@ class Sphere:
     def semiminor_axis(self):
         """
         The semiminor axis of the sphere is equal to its radius.
-        Definition: :math:`b = R`.
         Units: :math:`m`.
         """
         return self.radius
@@ -155,7 +154,6 @@ class Sphere:
     def semimedium_axis(self):
         """
         The semimedium axis of the sphere is equal to its radius.
-        Definition: :math:`a = R`.
         Units: :math:`m`.
         """
         return self.radius
@@ -164,7 +162,6 @@ class Sphere:
     def semimajor_axis(self):
         """
         The semimajor axis of the sphere is equal to its radius.
-        Definition: :math:`a = R`.
         Units: :math:`m`.
         """
         return self.radius

--- a/boule/tests/test_ellipsoid.py
+++ b/boule/tests/test_ellipsoid.py
@@ -105,6 +105,16 @@ def test_check_geocentric_grav_const():
 
 
 @pytest.mark.parametrize("ellipsoid", ELLIPSOIDS, ids=ELLIPSOID_NAMES)
+def test_semiaxes(ellipsoid):
+    """
+    Check that the semimedium axis is equal to the semimajor axis and that
+    the longitude of the semimajor axis is zero.
+    """
+    assert ellipsoid.semimedium_axis == ellipsoid.semimajor_axis
+    assert ellipsoid.semimajor_axis_longitude == 0
+
+
+@pytest.mark.parametrize("ellipsoid", ELLIPSOIDS, ids=ELLIPSOID_NAMES)
 def test_geodetic_to_spherical_on_equator(ellipsoid):
     "Test geodetic to geocentric coordinates conversion on equator."
     rtol = 1e-10

--- a/boule/tests/test_sphere.py
+++ b/boule/tests/test_sphere.py
@@ -72,6 +72,17 @@ def test_check_geocentric_grav_const():
         assert len(warn) >= 1
 
 
+def test_semiaxes(sphere):
+    """
+    Check that the semiaxes are all equal to the sphere radius and that
+    the longitude of the semimajor axis is zero.
+    """
+    assert sphere.semimajor_axis == sphere.radius
+    assert sphere.semimedium_axis == sphere.radius
+    assert sphere.semiminor_axis == sphere.radius
+    assert sphere.semimajor_axis_longitude == 0
+
+
 @pytest.mark.parametrize("si_units", [False, True], ids=["mGal", "SI"])
 def test_normal_gravity_pole_equator(sphere, si_units):
     """


### PR DESCRIPTION
**Squash and Merge comment**

Add `semimedium_axis` and `semimajor_axis_longitude`  to the Sphere and Ellipsoid classes for compatibility with the `TriaxialEllipsoid`. Don't use mathematical symbols for the `semimedium_axis`. Remove the "Added for compatibility with pymap3d" comment in some of the properties.

---

This PR adds the property `semimedium_axis`and `semimajor_axis_longitude`  to the Sphere and Ellipsoid classes. This is done for compatibility. I note that the Sphere class already had semiminor and semimajor axes set.

Furthermore, I have removed "Added for compatibility with pymap3d" from the docstring, as I encountered this compatibility problem in pyshtools... In many cases, people will treat (Sphere, Ellipsoid, TriaxialEllipsoid) as just a boule instance, and won't care which "subclass" they are dealing with.

**Relevant issues/PRs:**
None.