### PR TITLE
Run tests with oldest dependencies on x86 macos

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,19 +31,27 @@ jobs:
   # Run tests and upload to codecov
   test:
     name: ${{ matrix.os }} python=${{ matrix.python }} dependencies=${{ matrix.dependencies }}
-    runs-on: ${{ matrix.os }}-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       # Otherwise, the workflow would stop if a single job fails. We want to
       # run all of them to catch failures in different combinations.
       fail-fast: false
       matrix:
-        os: [ubuntu, macos, windows]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python: ["3.8", "3.12"]
         include:
           - python: "3.8"
             dependencies: oldest
           - python: "3.12"
             dependencies: latest
+          # test on macos-13 (x86) using oldest dependencies and python 3.8
+          - os: macos-13
+            python: "3.8"
+            dependencies: oldest
+        exclude:
+          # don't test on macos-latest (arm64) with oldest dependencies
+          - os: macos-latest
+            dependencies: oldest
     env:
       REQUIREMENTS: env/requirements-build.txt env/requirements-test.txt
       # Used to tag codecov submissions


### PR DESCRIPTION
Change configuration of tests in GitHub Actions: use the latest x86 macos runner with the `oldest` dependencies and Python 3.8. Use the latest macos runner (arm64) only against the `latest` and `optional` requirements. This fixes CI failing because there are not Numpy binaries in PyPI for arm64 and compatible with Python 3.8.

<!--
Thank you for contributing a pull request to Fatiando! 💖

👆🏽 ABOVE: Describe the changes proposed and WHY you made them.

👇🏽 BELOW: Link to any relevant issue or pull request.

Please ensure you have taken a look at the CONTRIBUTING.md file
in this repository (if available) and the general guidelines at
https://github.com/fatiando/community/blob/main/CONTRIBUTING.md
-->

**Relevant issues/PRs:**
<!--
Example: "Fixes #1234" / "See also #345" / "Relevant to #111"
Use keywords (e.g., Fixes, Closes) to create the links and automatically
close issues when this PR is merged.
See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Inspired in fatiando/harmonica#499
