### PR TITLE
Replace "geodetic" argument in geocentric_radius

### DIFF
--- a/boule/_ellipsoid.py
+++ b/boule/_ellipsoid.py
@@ -280,7 +280,9 @@ class Ellipsoid:
         n = 50
         x, weights = np.polynomial.legendre.leggauss(n)
         geocentric_latitude = 90.0 - np.rad2deg(np.arccos(x))
-        radius = self.geocentric_radius(geocentric_latitude, geodetic=False)
+        radius = self.geocentric_radius(
+            geocentric_latitude, coordinate_system="spherical"
+        )
         return np.sum(radius * weights) / 2
 
     @property
@@ -445,7 +447,7 @@ class Ellipsoid:
             )
         return s
 
-    def geocentric_radius(self, latitude, geodetic=True):
+    def geocentric_radius(self, latitude, coordinate_system="geodetic"):
         r"""
         Radial distance from the center of the ellipsoid to its surface.
 
@@ -456,10 +458,10 @@ class Ellipsoid:
         ----------
         latitude : float or array
             Latitude coordinates on geodetic coordinate system in degrees.
-        geodetic : bool
-            If True (default), will assume that latitudes are geodetic
-            latitudes. Otherwise, will assume that they are geocentric
-            spherical latitudes.
+        coordinate_system : str
+            The coordinate system that will be assumed for the given latitude.
+            Should be one of: ``"geodetic"`` (default) for geodetic latitudes
+            or ``"spherical"`` for geocentric spherical latitudes.
 
         Returns
         -------
@@ -508,11 +510,10 @@ class Ellipsoid:
         .. [1] See https://en.wikipedia.org/wiki/Earth_radius#Geocentric_radius
 
         """
+        check_coordinate_system(coordinate_system)
         latitude_rad = np.radians(latitude)
         coslat, sinlat = np.cos(latitude_rad), np.sin(latitude_rad)
-        # Avoid doing this in favour of having the user do the conversions when
-        # possible. It's not the case here, so we made an exception.
-        if geodetic:
+        if coordinate_system == "geodetic":
             radius = np.sqrt(
                 (
                     (self.semimajor_axis**2 * coslat) ** 2
@@ -1067,3 +1068,26 @@ class Ellipsoid:
             * (self.prime_vertical_radius(sinlat) + height)
             * coslat
         ) ** 2
+
+
+def check_coordinate_system(coordinate_system, valid=("geodetic", "spherical")):
+    """
+    Make sure the coordinate system is valid.
+
+    Parameters
+    ----------
+    coordinate_system : str
+        A string specifying the coordinate system to use.
+    valid : list of str
+        List of valid values for the coordinate system.
+
+    Raises
+    ------
+    ValueError
+        If the coordinate system is not in the valid list.
+    """
+    if coordinate_system not in valid:
+        message = (
+            f"Invalid coordinate system '{coordinate_system}'. Must be one of {valid}."
+        )
+        raise ValueError(message)

--- a/boule/tests/test_ellipsoid.py
+++ b/boule/tests/test_ellipsoid.py
@@ -14,10 +14,24 @@ import numpy.testing as npt
 import pytest
 
 from .. import GRS80, WGS84, Ellipsoid, Mars2009
+from .._ellipsoid import check_coordinate_system
 from .utils import normal_gravity_surface
 
 ELLIPSOIDS = [WGS84, GRS80, Mars2009]
 ELLIPSOID_NAMES = [e.name for e in ELLIPSOIDS]
+
+
+@pytest.mark.parametrize("coordinate_system", ("geocentric", "bla", "ellipsoidal"))
+def test_check_coordinate_system_fails(coordinate_system):
+    "Make sure an exception is raised for invalid inputs"
+    with pytest.raises(ValueError, match="Invalid coordinate system"):
+        check_coordinate_system(coordinate_system)
+
+
+@pytest.mark.parametrize("coordinate_system", ("geodetic", "spherical"))
+def test_check_coordinate_system_passes(coordinate_system):
+    "Make sure no exception is raised for valid inputs"
+    check_coordinate_system(coordinate_system)
 
 
 def test_check_flattening():
@@ -335,7 +349,7 @@ def test_geocentric_radius_geocentric(ellipsoid):
     )[1:]
     npt.assert_allclose(
         radius_conversion,
-        ellipsoid.geocentric_radius(latitude_spherical, geodetic=False),
+        ellipsoid.geocentric_radius(latitude_spherical, coordinate_system="spherical"),
     )
 
 
@@ -347,7 +361,8 @@ def test_geocentric_radius_geocentric_pole_equator(ellipsoid):
         [ellipsoid.semiminor_axis, ellipsoid.semiminor_axis, ellipsoid.semimajor_axis]
     )
     npt.assert_allclose(
-        radius_true, ellipsoid.geocentric_radius(latitude, geodetic=False)
+        radius_true,
+        ellipsoid.geocentric_radius(latitude, coordinate_system="spherical"),
     )
 
 

--- a/boule/tests/test_triaxialellipsoid.py
+++ b/boule/tests/test_triaxialellipsoid.py
@@ -291,7 +291,9 @@ def test_geocentric_radius_biaxialellipsoid(triaxialellipsoid):
 
     # Compute the reference geocentric radii using the reference biaxial
     # ellipsoid
-    radius_true = biaxialellipsoid_ref.geocentric_radius(latitude, geodetic=False)
+    radius_true = biaxialellipsoid_ref.geocentric_radius(
+        latitude, coordinate_system="spherical"
+    )
     npt.assert_allclose(
         radius_true, biaxialellipsoid.geocentric_radius(longitude, latitude)
     )


### PR DESCRIPTION
This is a backwards incompatible change. Use `coordinate_system` instead since we will be moving towards that definition in other functions (see #175). Create a function to check that the argument has a valid value. This way all arguments relating to coordinate systems will be consistent and we can add support for ellipsoidal harmonic coordinates as well.