### PR TITLE
Add spherical to cartesian conversion for Ellipsoid

### DIFF
--- a/boule/_ellipsoid.py
+++ b/boule/_ellipsoid.py
@@ -150,6 +150,9 @@ class Ellipsoid:
     reference = attr.ib(default=None)
     comments = attr.ib(default=None)
 
+    # Attribute validation
+    # ##################################################################################
+
     @flattening.validator
     def _check_flattening(self, flattening, value):
         "Check if flattening is valid"
@@ -183,6 +186,9 @@ class Ellipsoid:
         "Warn if geocentric_grav_const is negative"
         if value < 0:
             warn(f"The geocentric gravitational constant is negative: '{value}'")
+
+    # Properties
+    # ##################################################################################
 
     @property
     def semiminor_axis(self):
@@ -446,6 +452,9 @@ class Ellipsoid:
                 subsequent_indent=2 * " ",
             )
         return s
+
+    # Coordinates and conversions
+    # ##################################################################################
 
     def geocentric_radius(self, latitude, coordinate_system="geodetic"):
         r"""
@@ -776,6 +785,46 @@ class Ellipsoid:
         )
 
         return longitude, np.degrees(latitude), height
+
+    def spherical_to_cartesian(self, coordinates):
+        """
+        Convert from spherical coordinates to geocentric Cartesian coordinates.
+
+        In the geocentric Cartesian system, z is aligned with the Earth's axis
+        of rotation and points towards the North pole, x and y are contained in
+        the equatorial plane, x coincides with the Greenwich meridian, and
+        y completes right-handed coordinate system.
+
+        Parameters
+        ----------
+        coordinates : tuple = (longitude, latitude_spherical, height)
+            Longitude, latitude, and radius coordinates of the points in
+            a geocentric spherical coordinate system. Each element can be
+            a single number or an array. The shape of the arrays must be
+            compatible. Longitude and latitude must be in degrees and radius in
+            meters.
+
+        Returns
+        -------
+        converted_coordinates : tuple = (x, y, z)
+            The converted x, y, z coordinates in a geocentric Cartesian
+            coordinate system. The shape of each element will be compatible
+            with the shape of the inputs. All coordinates are in meters.
+        """
+        longitude, latitude, radius = coordinates
+        latitude_radians = np.radians(latitude)
+        longitude_radians = np.radians(longitude)
+        sinlat = np.sin(latitude_radians)
+        coslat = np.cos(latitude_radians)
+        sinlon = np.sin(longitude_radians)
+        coslon = np.cos(longitude_radians)
+        x = radius * coslat * coslon
+        y = radius * coslat * sinlon
+        z = radius * sinlat
+        return x, y, z
+
+    # Gravity
+    # ##################################################################################
 
     def normal_gravity(self, coordinates, si_units=False):
         r"""

--- a/boule/tests/test_ellipsoid.py
+++ b/boule/tests/test_ellipsoid.py
@@ -12,6 +12,7 @@ import warnings
 import numpy as np
 import numpy.testing as npt
 import pytest
+import pymap3d
 
 from .. import GRS80, WGS84, Ellipsoid, Mars2009
 from .._ellipsoid import check_coordinate_system
@@ -190,6 +191,41 @@ def test_spherical_to_geodetic_on_poles(ellipsoid):
     npt.assert_allclose(spherical_longitude, longitude, rtol=rtol)
     npt.assert_allclose(spherical_latitude, latitude, rtol=rtol)
     npt.assert_allclose(radius, height + ellipsoid.semiminor_axis, rtol=rtol)
+
+
+@pytest.mark.parametrize("ellipsoid", ELLIPSOIDS, ids=ELLIPSOID_NAMES)
+def test_spherical_to_cartesian_on_equator(ellipsoid):
+    "Test spherical to cartesian coordinates conversion on equator."
+    rtol = 1e-10
+    atol = 1e-8
+    longitude = np.array([0, 90, 180, 270])
+    spherical_latitude = np.zeros_like(longitude)
+    radius = 1000 + ellipsoid.semimajor_axis
+    x, y, z = ellipsoid.spherical_to_cartesian((longitude, spherical_latitude, radius))
+    npt.assert_allclose(radius, x[0], rtol=rtol)
+    npt.assert_allclose(-radius, x[2], rtol=rtol)
+    npt.assert_allclose(0, x[1], rtol=0, atol=atol)
+    npt.assert_allclose(0, x[3], rtol=0, atol=atol)
+    npt.assert_allclose(radius, y[1], rtol=rtol)
+    npt.assert_allclose(-radius, y[3], rtol=rtol)
+    npt.assert_allclose(0, y[0], rtol=0, atol=atol)
+    npt.assert_allclose(0, y[2], rtol=0, atol=atol)
+    npt.assert_allclose(0, z, rtol=0, atol=atol)
+
+
+@pytest.mark.parametrize("ellipsoid", ELLIPSOIDS, ids=ELLIPSOID_NAMES)
+def test_spherical_to_cartesian_on_pole(ellipsoid):
+    "Test spherical to cartesian coordinates conversion on the pole."
+    rtol = 1e-10
+    atol = 1e-8
+    spherical_latitude = np.array([90, -90])
+    longitude = np.zeros_like(spherical_latitude)
+    radius = 1000 + ellipsoid.semiminor_axis
+    x, y, z = ellipsoid.spherical_to_cartesian((longitude, spherical_latitude, radius))
+    npt.assert_allclose(radius, z[0], rtol=rtol)
+    npt.assert_allclose(-radius, z[1], rtol=rtol)
+    npt.assert_allclose(0, x, rtol=0, atol=atol)
+    npt.assert_allclose(0, y, rtol=0, atol=atol)
 
 
 @pytest.mark.parametrize("ellipsoid", ELLIPSOIDS, ids=ELLIPSOID_NAMES)


### PR DESCRIPTION
Add methods to convert to and from geocentric spherical to geocentric Cartesian coordinates to the `Ellipsoid` class. Functions take a `coordinates` tuple and performs the conversions. Cartesian coordinates are returned in meters.

**Relevant issues/PRs:** Part of #191 