### PR TITLE
Remove the top-level CITATION file

### DIFF
--- a/CITATION.rst
+++ b/CITATION.rst
@@ -1,8 +1,0 @@
-Citing Boule
-============
-
-This is research software **made by scientists**. Citations help us justify the
-effort that goes into building and maintaining this project.
-
-If you used Boule in your research, please consider
-citing the latest Zenodo archive: https://doi.org/10.5281/zenodo.3530749

--- a/doc/citing.rst
+++ b/doc/citing.rst
@@ -1,3 +1,10 @@
 .. _citing:
 
-.. include:: ../CITATION.rst
+Citing Boule
+============
+
+This is research software **made by scientists**. Citations help us justify the
+effort that goes into building and maintaining this project.
+
+If you used Boule in your research, please consider
+citing the latest Zenodo archive: https://doi.org/10.5281/zenodo.3530749


### PR DESCRIPTION
We don't really reference this file too often and it's mostly used as a source for the citing page of the docs (which I guess if where most people will find the citation information). Remove the top level file and add the information directly to the docs page.