### PR TITLE
General improvements to install and version compatibility pages

### DIFF
--- a/doc/compatibility.rst
+++ b/doc/compatibility.rst
@@ -16,6 +16,8 @@ Boule uses `semantic versioning <https://semver.org/>`__ (i.e.,
 * Bug fix releases fix errors in a previous release without adding new
   functionality. Users can upgrade minor versions without changing their code.
 
+**We aim for Boule to be backwards compatible whenever possible and will make
+major releases sparingly and with ample warning.**
 We will add ``FutureWarning`` messages about deprecations ahead of making any
 breaking changes to give users a chance to upgrade.
 
@@ -23,8 +25,9 @@ breaking changes to give users a chance to upgrade.
 
     The above does not apply to versions < ``1.0.0``. All ``0.*`` versions may
     deprecate, remove, or change functionality between releases. Proper
-    warnings will be raised and any breaking changes will be marked as such in
+    warnings may be raised, and any breaking changes will be marked as such in
     the :ref:`changes`.
+
 
 .. _dependency-versions:
 
@@ -42,6 +45,11 @@ older ones are still working without causing problems.
 Whenever support for a version is dropped, we will include a note in the
 :ref:`changes`.
 
+.. seealso::
+
+    Exact version constraints on our dependencies can be found in the
+    `pyproject.toml file <https://github.com/fatiando/boule/blob/main/pyproject.toml>`__.
+
 .. note::
 
     This was introduced in Boule v0.4.0.
@@ -52,6 +60,7 @@ Whenever support for a version is dropped, we will include a note in the
 Supported Python versions
 -------------------------
 
+Boule supports Python versions greater than the ones listed below.
 If you require support for older Python versions, please pin Boule to the
 following releases to ensure compatibility:
 

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -7,22 +7,22 @@ There are different ways to install Boule:
 
 .. tab-set::
 
-    .. tab-item:: pip
-
-        Using the `pip package manager <https://pypi.org/project/pip/>`__:
-
-        .. code:: bash
-
-            pip install boule
-
     .. tab-item:: conda/mamba
 
-        Using the `conda package manager <https://conda.io/>`__ (or ``mamba``)
-        that comes with the Anaconda/Miniconda distribution:
+        Using the `conda <https://conda.io/>`__ package manager (or ``mamba``)
+        that comes with the Anaconda, Miniconda, or Miniforge distributions:
 
         .. code:: bash
 
             conda install boule --channel conda-forge
+
+    .. tab-item:: pip
+
+        Using the `pip <https://pypi.org/project/pip/>`__ package manager:
+
+        .. code:: bash
+
+            python -m pip install boule
 
     .. tab-item:: Development version
 
@@ -33,26 +33,50 @@ There are different ways to install Boule:
 
             python -m pip install --upgrade git+https://github.com/fatiando/boule
 
+.. tip::
+
+    The commands above should be executed in a terminal. On Windows, use the
+    ``cmd.exe`` or the "Anaconda Prompt" / "Miniforge Prompt" app if you're using
+    Anaconda / Miniforge.
+
+.. admonition:: Which Python?
+    :class: tip
+
+    See :ref:`python-versions` for a list of supported Python versions.
+
 .. note::
 
-   The commands above should be executed in a terminal. On Windows, use the
-   ``cmd.exe`` or the "Anaconda Prompt" app if you’re using Anaconda.
+   We recommend using the
+   `Miniforge distribution <https://conda-forge.org/download/>`__
+   to ensure that you have the ``conda`` package manager available.
+   Installing Miniforge does not require administrative rights to your computer
+   and doesn't interfere with any other Python installations in your system.
+   It's also much smaller than the Anaconda distribution and is less likely to
+   break when installing new software.
 
 
-Which Python?
--------------
-
-You'll need **Python >= 3.8**.
-See :ref:`python-versions` if you require support for older versions.
+.. _dependencies:
 
 Dependencies
 ------------
 
 These required dependencies should be installed automatically when you install
-Boule with ``pip`` or ``conda``:
+Boule with ``pip`` or ``conda``.
+Optional dependencies have to be installed manually.
 
 * `numpy <http://www.numpy.org/>`__
 * `attrs <https://www.attrs.org/>`__
 
-See :ref:`dependency-versions` for the our policy of oldest supported versions
-of each dependency.
+
+.. note::
+
+    See :ref:`dependency-versions` for our policy of oldest supported
+    versions of each dependency.
+
+The examples in documentation also use:
+
+* `matplotlib <https://matplotlib.org/>`__ for plotting
+* `pygmt <https://www.pygmt.org/>`__ for making maps
+* `xarray <https://xarray.dev/>`__ for handling grids
+* `bordado <https://www.fatiando.org/bordado>`__ for generating grid coordinates
+* `ensaio <https://www.fatiando.org/ensaio>`__ for downloading sample data


### PR DESCRIPTION
Add more links to other sections, including the version compatibility. Add statement about the minimum Python version required. Prioritize the miniforge install and recommendation. Add the dependency version policy and link to pyproject.toml.