### PR TITLE
Fix: use -depth with find to safely delete temp folders

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,9 +43,8 @@ check-actions:
 	zizmor $(GITHUB_ACTIONS)
 
 clean:
-	find . -name "*.pyc" -exec rm -v {} \;
 	find . -name "*.orig" -exec rm -v {} \;
 	find . -name ".coverage.*" -exec rm -v {} \;
-	find . -name "__pycache__" -exec rm -v {} \;
-	find . -name "*.egg-info " -exec rm -v {} \;
+	find . -depth -name "__pycache__" -exec rm -v {} \;
+	find . -depth -name "*.egg-info " -exec rm -v {} \;
 	rm -rvf build dist MANIFEST .coverage .cache .pytest_cache src/$(PROJECT)/_version.py


### PR DESCRIPTION
Previously, the find commands failed to delete temporary directories because find processes top-down (parent to child) while rm deletes the parent first. This led to "missing folder" errors that halted subsequent commands.

Passing the -depth flag forces find to process a directory's contents before the directory itself, resolving the conflict.

Related to: https://github.com/fatiando/bordado/pull/87